### PR TITLE
Fix QuiltLoader blacklisting fabric loader rather than quilt loader.

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -251,7 +251,7 @@ public class QuiltLoaderImpl implements FabricLoader {
 		// add mods to classpath
 		// TODO: This can probably be made safer, but that's a long-term goal
 		for (ModContainer mod : mods) {
-			if (!mod.getInfo().getId().equals("fabricloader") && !mod.getInfo().getType().equals("builtin")) {
+			if (!mod.getInfo().getId().equals("quilt_loader") && !mod.getInfo().getType().equals("builtin")) {
 				QuiltLauncherBase.getLauncher().propose(mod.getOriginUrl());
 			}
 		}


### PR DESCRIPTION
This fixes this crash for me:
````
java.lang.RuntimeException: Cannot instantiate mods when not frozen!
	at org.quiltmc.loader.impl.QuiltLoaderImpl.prepareModInit(QuiltLoaderImpl.java:447)
	at org.quiltmc.loader.impl.entrypoint.minecraft.hooks.EntrypointClient.start(EntrypointClient.java:31)
	at net.minecraft.client.MinecraftClient.<init>(MinecraftClient.java:420)
	at net.minecraft.client.main.Main.main(Main.java:149)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.quiltmc.loader.impl.game.MinecraftGameProvider.launch(MinecraftGameProvider.java:221)
	at org.quiltmc.loader.impl.launch.knot.Knot.launch(Knot.java:146)
	at org.quiltmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:28)
	at org.quiltmc.devlaunchinjector.Main.main(Main.java:86)
````