### PR TITLE
Ignore $schema in v1 fabric.mod.json files instead of warning

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/metadata/ModMetadataParser.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/ModMetadataParser.java
@@ -65,7 +65,8 @@ public final class ModMetadataParser {
 
 				while (reader.hasNext()) {
 					// Try to read the schemaVersion
-					final String nextName = reader.nextName();
+					String nextName = reader.nextName();
+
 					if (nextName.equals("schemaVersion")) {
 						if (reader.peek() != JsonToken.NUMBER) {
 							throw new ParseMetadataException("\"schemaVersion\" must be a number.", reader);

--- a/src/main/java/org/quiltmc/loader/impl/metadata/ModMetadataParser.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/ModMetadataParser.java
@@ -65,7 +65,8 @@ public final class ModMetadataParser {
 
 				while (reader.hasNext()) {
 					// Try to read the schemaVersion
-					if (reader.nextName().equals("schemaVersion")) {
+					final String nextName = reader.nextName();
+					if (nextName.equals("schemaVersion")) {
 						if (reader.peek() != JsonToken.NUMBER) {
 							throw new ParseMetadataException("\"schemaVersion\" must be a number.", reader);
 						}
@@ -76,6 +77,10 @@ public final class ModMetadataParser {
 							// Finish reading the metadata
 							return readModMetadata(logger, reader, schemaVersion);
 						}
+					} else if (nextName.equals("$schema")) {
+						reader.skipValue();
+						// Avoid setting firstField to false, to prevent using the slow route when $schema is before schemaVersion
+						continue;
 
 						// schemaVersion found, but after some content -> start over to parse all data with the detected version
 					} else {

--- a/src/main/java/org/quiltmc/loader/impl/metadata/V1ModMetadataParser.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/V1ModMetadataParser.java
@@ -208,6 +208,9 @@ final class V1ModMetadataParser {
 			case "custom":
 				readCustomValues(reader, customValues);
 				break;
+			case "$schema":
+				reader.skipValue();
+				break;
 			default:
 				warnings.add(new ParseWarning(reader.locationString(), key, "Unsupported root entry"));
 				reader.skipValue();


### PR DESCRIPTION
[JSON Schema](https://json-schema.org) specifies that the `$schema` key is used to set the JSON schema used for the file.
By ignoring this key instead of printing a warning, it becomes possible to specify such a schema for the editor support _without_ causing warnings on every load of the mod.

