### PR TITLE
Clean up compiler warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 	id 'eclipse'
 	id 'maven-publish'
 	id("org.cadixdev.licenser") version "0.5.0"
-    id("org.quiltmc.loom") version "0.7.13"
+	id("org.quiltmc.loom") version "0.7.13"
 }
 
 sourceCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 	id 'eclipse'
 	id 'maven-publish'
 	id("org.cadixdev.licenser") version "0.5.0"
-    id("org.quiltmc.loom") version "0.7.12"
+    id("org.quiltmc.loom") version "0.7.13"
 }
 
 sourceCompatibility = 1.8

--- a/src/main/java/net/fabricmc/loader/api/EntrypointException.java
+++ b/src/main/java/net/fabricmc/loader/api/EntrypointException.java
@@ -21,6 +21,7 @@ package net.fabricmc.loader.api;
  * 
  * @see FabricLoader#getEntrypointContainers(String, Class) 
  */
+@SuppressWarnings("serial")
 public class EntrypointException extends RuntimeException {
 	private final String key;
 

--- a/src/main/java/net/fabricmc/loader/api/LanguageAdapterException.java
+++ b/src/main/java/net/fabricmc/loader/api/LanguageAdapterException.java
@@ -21,6 +21,7 @@ package net.fabricmc.loader.api;
  *
  * @see LanguageAdapter
  */
+@SuppressWarnings("serial")
 public class LanguageAdapterException extends Exception {
 	/**
 	 * Creates a new language adapter exception.

--- a/src/main/java/net/fabricmc/loader/api/VersionParsingException.java
+++ b/src/main/java/net/fabricmc/loader/api/VersionParsingException.java
@@ -16,7 +16,7 @@
 
 package net.fabricmc.loader.api;
 
-@SuppressWarnings("deprecation") //Extending the deprecated one for backwards compatibility
+@SuppressWarnings({ "deprecation", "serial" }) //Extending the deprecated one for backwards compatibility
 public class VersionParsingException extends org.quiltmc.loader.impl.util.version.VersionParsingException {
 	public VersionParsingException() {
 		super();

--- a/src/main/java/org/quiltmc/loader/impl/DependencyException.java
+++ b/src/main/java/org/quiltmc/loader/impl/DependencyException.java
@@ -16,6 +16,7 @@
 
 package org.quiltmc.loader.impl;
 
+@SuppressWarnings("serial")
 public class DependencyException extends RuntimeException {
 
 	public DependencyException() {

--- a/src/main/java/org/quiltmc/loader/impl/EntrypointStorage.java
+++ b/src/main/java/org/quiltmc/loader/impl/EntrypointStorage.java
@@ -33,6 +33,7 @@ class EntrypointStorage {
 		ModContainer getModContainer();
 	}
 
+	@SuppressWarnings("deprecation")
 	private static class OldEntry implements Entry {
 		private static final org.quiltmc.loader.impl.language.LanguageAdapter.Options options = org.quiltmc.loader.impl.language.LanguageAdapter.Options.Builder.create()
 			.missingSuperclassBehaviour(org.quiltmc.loader.impl.language.LanguageAdapter.MissingSuperclassBehavior.RETURN_NULL)
@@ -64,8 +65,9 @@ class EntrypointStorage {
 			if (object == null || !type.isAssignableFrom(object.getClass())) {
 				return null;
 			} else {
-				//noinspection unchecked
-				return (T) object;
+				@SuppressWarnings("unchecked")
+				T tmp = (T) object;
+				return tmp;
 			}
 		}
 
@@ -99,8 +101,9 @@ class EntrypointStorage {
 				o = create(type);
 				instanceMap.put(type, o);
 			}
-			//noinspection unchecked
-			return (T) o;
+			@SuppressWarnings("unchecked")
+			T tmp = (T) o;
+			return tmp;
 		}
 
 		@Override
@@ -142,6 +145,7 @@ class EntrypointStorage {
 		return entryMap.containsKey(key);
 	}
 
+	@SuppressWarnings("deprecation") // internal use, ignore warning deprecation
 	protected <T> List<T> getEntrypoints(String key, Class<T> type) {
 		List<Entry> entries = entryMap.get(key);
 		if (entries == null) return Collections.emptyList();
@@ -172,6 +176,7 @@ class EntrypointStorage {
 		return results;
 	}
 
+	@SuppressWarnings("deprecation") // internal use, ignore warning deprecation
 	protected <T> List<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type) {
 		List<Entry> entries = entryMap.get(key);
 		if (entries == null) return Collections.emptyList();

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -29,10 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
 import org.jetbrains.annotations.ApiStatus;
@@ -174,21 +171,6 @@ public class QuiltLoaderImpl implements FabricLoader {
 	@Deprecated
 	public File getModsDirectory() {
 		return getModsDir().toFile();
-	}
-
-	private String join(Stream<String> strings, String joiner) {
-		StringBuilder builder = new StringBuilder();
-		AtomicInteger i = new AtomicInteger();
-
-		strings.sequential().forEach((s) -> {
-			if ((i.getAndIncrement()) > 0) {
-				builder.append(joiner);
-			}
-
-			builder.append(s);
-		});
-
-		return builder.toString();
 	}
 
 	public void load() {

--- a/src/main/java/org/quiltmc/loader/impl/QuiltMappingResolver.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltMappingResolver.java
@@ -28,7 +28,7 @@ import net.fabricmc.loader.api.MappingResolver;
 import net.fabricmc.mapping.tree.ClassDef;
 import net.fabricmc.mapping.tree.Descriptored;
 import net.fabricmc.mapping.tree.TinyTree;
-import net.fabricmc.mappings.EntryTriple;
+import net.fabricmc.mapping.util.EntryTriple;
 
 class QuiltMappingResolver implements MappingResolver {
 	private final Supplier<TinyTree> mappingsSupplier;

--- a/src/main/java/org/quiltmc/loader/impl/discovery/ModCandidateSet.java
+++ b/src/main/java/org/quiltmc/loader/impl/discovery/ModCandidateSet.java
@@ -31,8 +31,9 @@ public class ModCandidateSet {
 		Version bv = b.getInfo().getVersion();
 
 		if (av instanceof Comparable && bv instanceof Comparable) {
-			//noinspection unchecked
-			return ((Comparable) bv).compareTo(av);
+			@SuppressWarnings("unchecked")
+			Comparable<? super Version> cv = (Comparable<? super Version>) bv; 
+			return (cv.compareTo(av));
 		} else {
 			return 0;
 		}

--- a/src/main/java/org/quiltmc/loader/impl/discovery/ModResolutionException.java
+++ b/src/main/java/org/quiltmc/loader/impl/discovery/ModResolutionException.java
@@ -16,6 +16,7 @@
 
 package org.quiltmc.loader.impl.discovery;
 
+@SuppressWarnings("serial")
 public class ModResolutionException extends Exception {
 	public ModResolutionException(String s) {
 		super(s);

--- a/src/main/java/org/quiltmc/loader/impl/discovery/ModResolver.java
+++ b/src/main/java/org/quiltmc/loader/impl/discovery/ModResolver.java
@@ -551,6 +551,7 @@ public class ModResolver {
 		return errorList.isEmpty();
 	}
 
+	@SuppressWarnings("serial")
 	static class UrlProcessAction extends RecursiveAction {
 		private final QuiltLoaderImpl loader;
 		private final Map<String, ModCandidateSet> candidatesById;

--- a/src/main/java/org/quiltmc/loader/impl/discovery/ModResolver.java
+++ b/src/main/java/org/quiltmc/loader/impl/discovery/ModResolver.java
@@ -292,8 +292,9 @@ public class ModResolver {
 				for (ModCandidate other : modCandidateMap.get(candidate.getInfo().getId())) {
 					Version otherVersion = other.getInfo().getVersion();
 					if (version instanceof Comparable && otherVersion instanceof Comparable && !version.equals(otherVersion)) {
-						//noinspection unchecked
-						if (((Comparable) version).compareTo(otherVersion) == 0) {
+						@SuppressWarnings("unchecked")
+						Comparable<? super Version> cv = (Comparable<? super Version>) version;
+						if (cv.compareTo(otherVersion) == 0) {
 							suspiciousVersions.add(otherVersion);
 						}
 					}

--- a/src/main/java/org/quiltmc/loader/impl/entrypoint/applet/AppletFrame.java
+++ b/src/main/java/org/quiltmc/loader/impl/entrypoint/applet/AppletFrame.java
@@ -33,6 +33,7 @@ import java.io.File;
  *
  * It has been adapted here for the purposes of the Fabric loader.
  */
+@SuppressWarnings("serial")
 public class AppletFrame extends Frame implements WindowListener {
 	private AppletLauncher applet = null;
 

--- a/src/main/java/org/quiltmc/loader/impl/entrypoint/applet/AppletLauncher.java
+++ b/src/main/java/org/quiltmc/loader/impl/entrypoint/applet/AppletLauncher.java
@@ -38,6 +38,7 @@ import java.util.Map;
  *
  * It has been adapted here for the purposes of the Fabric loader.
  */
+@SuppressWarnings("serial")
 public class AppletLauncher extends Applet implements AppletStub {
 	public static File gameDir;
 

--- a/src/main/java/org/quiltmc/loader/impl/entrypoint/applet/AppletLauncher.java
+++ b/src/main/java/org/quiltmc/loader/impl/entrypoint/applet/AppletLauncher.java
@@ -87,15 +87,6 @@ public class AppletLauncher extends Applet implements AppletStub {
 		}
 	}
 
-	private URL pathToUrl(File path) {
-		try {
-			return path.toURI().toURL();
-		} catch (MalformedURLException e) {
-			e.printStackTrace();
-		}
-		return null;
-	}
-
 	@Override
 	public void appletResize(int width, int height) {
 		mcApplet.resize(width, height);

--- a/src/main/java/org/quiltmc/loader/impl/entrypoint/minecraft/hooks/EntrypointUtils.java
+++ b/src/main/java/org/quiltmc/loader/impl/entrypoint/minecraft/hooks/EntrypointUtils.java
@@ -24,7 +24,6 @@ import java.util.function.Consumer;
 
 public final class EntrypointUtils {
 	public static <T> void invoke(String name, Class<T> type, Consumer<? super T> invoker) {
-		@SuppressWarnings("deprecation")
 		QuiltLoaderImpl loader = QuiltLoaderImpl.INSTANCE;
 
 		if (!loader.hasEntrypoints(name)) {
@@ -35,7 +34,6 @@ public final class EntrypointUtils {
 	}
 
 	private static <T> void invoke0(String name, Class<T> type, Consumer<? super T> invoker) {
-		@SuppressWarnings("deprecation")
 		QuiltLoaderImpl loader = QuiltLoaderImpl.INSTANCE;
 		RuntimeException exception = null;
 		Collection<EntrypointContainer<T>> entrypoints = loader.getEntrypointContainers(name, type);

--- a/src/main/java/org/quiltmc/loader/impl/gui/QuiltMainWindow.java
+++ b/src/main/java/org/quiltmc/loader/impl/gui/QuiltMainWindow.java
@@ -479,7 +479,7 @@ class QuiltMainWindow {
 		}
 
 		@Override
-		public Enumeration children() {
+		public Enumeration<? extends TreeNode> children() {
 			return new Enumeration<CustomTreeNode>() {
 				Iterator<CustomTreeNode> it = displayedChildren.iterator();
 

--- a/src/main/java/org/quiltmc/loader/impl/language/LanguageAdapter.java
+++ b/src/main/java/org/quiltmc/loader/impl/language/LanguageAdapter.java
@@ -27,7 +27,7 @@ public interface LanguageAdapter {
 
 	default Object createInstance(String classString, Options options) throws ClassNotFoundException, LanguageAdapterException {
 		try {
-			Class c = JavaLanguageAdapter.getClass(classString, options);
+			Class<?> c = JavaLanguageAdapter.getClass(classString, options);
 			if (c != null) {
 				return createInstance(c, options);
 			} else {

--- a/src/main/java/org/quiltmc/loader/impl/language/LanguageAdapterException.java
+++ b/src/main/java/org/quiltmc/loader/impl/language/LanguageAdapterException.java
@@ -16,6 +16,7 @@
 
 package org.quiltmc.loader.impl.language;
 
+@SuppressWarnings("serial")
 @Deprecated
 public class LanguageAdapterException extends Exception {
 	public LanguageAdapterException(String s) {

--- a/src/main/java/org/quiltmc/loader/impl/launch/QuiltTweaker.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/QuiltTweaker.java
@@ -115,7 +115,6 @@ public abstract class QuiltTweaker extends QuiltLauncherBase implements ITweaker
 			throw new RuntimeException("Could not locate Minecraft: provider locate failed");
 		}
 
-		@SuppressWarnings("deprecation")
 		QuiltLoaderImpl loader = QuiltLoaderImpl.INSTANCE;
 		loader.setGameProvider(provider);
 		loader.load();
@@ -214,8 +213,9 @@ public abstract class QuiltTweaker extends QuiltLauncherBase implements ITweaker
 		try {
 			Field f = LaunchClassLoader.class.getDeclaredField("resourceCache");
 			f.setAccessible(true);
-			//noinspection unchecked
-			resourceCache = (Map<String, byte[]>) f.get(launchClassLoader);
+			@SuppressWarnings("unchecked")
+			Map<String, byte[]> tmp = (Map<String, byte[]>) f.get(launchClassLoader);
+			resourceCache = tmp;
 		} catch (Exception e) {
 			e.printStackTrace();
 		}

--- a/src/main/java/org/quiltmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/knot/Knot.java
@@ -120,7 +120,6 @@ public final class Knot extends QuiltLauncherBase {
 
 		Thread.currentThread().setContextClassLoader(cl);
 
-		@SuppressWarnings("deprecation")
 		QuiltLoaderImpl loader = QuiltLoaderImpl.INSTANCE;
 		loader.setGameProvider(provider);
 		loader.load();

--- a/src/main/java/org/quiltmc/loader/impl/launch/server/InjectingURLClassLoader.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/server/InjectingURLClassLoader.java
@@ -32,7 +32,7 @@ class InjectingURLClassLoader extends URLClassLoader {
 	@Override
 	protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
 		synchronized (getClassLoadingLock(name)) {
-			Class c = findLoadedClass(name);
+			Class<?> c = findLoadedClass(name);
 
 			if (c == null) {
 				boolean excluded = false;

--- a/src/main/java/org/quiltmc/loader/impl/metadata/ParseMetadataException.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/ParseMetadataException.java
@@ -19,6 +19,7 @@ package org.quiltmc.loader.impl.metadata;
 
 import org.quiltmc.json5.JsonReader;
 
+@SuppressWarnings("serial")
 public class ParseMetadataException extends Exception {
 	public ParseMetadataException(String message) {
 		super(message);

--- a/src/main/java/org/quiltmc/loader/impl/metadata/V0ModMetadata.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/V0ModMetadata.java
@@ -274,12 +274,6 @@ final class V0ModMetadata extends AbstractModMetadata implements LoaderModMetada
 		final Collection<String> common;
 		final Collection<String> server;
 
-		private Mixins() {
-			this.client = Collections.emptyList();
-			this.common = Collections.emptyList();
-			this.server = Collections.emptyList();
-		}
-
 		Mixins(Collection<String> client, Collection<String> common, Collection<String> server) {
 			this.client = Collections.unmodifiableCollection(client);
 			this.common = Collections.unmodifiableCollection(common);

--- a/src/main/java/org/quiltmc/loader/impl/minecraft/McVersionLookup.java
+++ b/src/main/java/org/quiltmc/loader/impl/minecraft/McVersionLookup.java
@@ -26,6 +26,8 @@ import java.nio.file.Path;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import net.fabricmc.loader.api.VersionParsingException;
+
 import org.quiltmc.json5.JsonReader;
 import org.quiltmc.json5.JsonToken;
 import org.quiltmc.loader.impl.QuiltLoaderImpl;
@@ -41,7 +43,6 @@ import org.quiltmc.loader.impl.metadata.ParseMetadataException;
 import org.quiltmc.loader.impl.util.FileSystemUtil;
 import org.quiltmc.loader.impl.util.version.SemanticVersionImpl;
 import org.quiltmc.loader.impl.util.version.SemanticVersionPredicateParser;
-import org.quiltmc.loader.impl.util.version.VersionParsingException;
 
 public final class McVersionLookup {
 	private static final Pattern VERSION_PATTERN = Pattern.compile(

--- a/src/main/java/org/quiltmc/loader/impl/util/DefaultLanguageAdapter.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/DefaultLanguageAdapter.java
@@ -49,8 +49,9 @@ public final class DefaultLanguageAdapter implements LanguageAdapter {
 		if (methodSplit.length == 1) {
 			if (type.isAssignableFrom(c)) {
 				try {
-					//noinspection unchecked
-					return (T) c.getDeclaredConstructor().newInstance();
+					@SuppressWarnings("unchecked")
+					T tmp = (T) c.getDeclaredConstructor().newInstance();
+					return tmp;
 				} catch (Exception e) {
 					throw new LanguageAdapterException(e);
 				}
@@ -83,8 +84,9 @@ public final class DefaultLanguageAdapter implements LanguageAdapter {
 					throw new LanguageAdapterException("Field " + value + " cannot be cast to " + type.getName() + "!");
 				}
 
-				//noinspection unchecked
-				return (T) field.get(null);
+				@SuppressWarnings("unchecked")
+				T tmp = (T) field.get(null);
+				return tmp;
 			} catch (NoSuchFieldException e) {
 				// ignore
 			} catch (IllegalAccessException e) {
@@ -114,13 +116,14 @@ public final class DefaultLanguageAdapter implements LanguageAdapter {
 
 			final Object targetObject = object;
 
-			//noinspection unchecked
-			return (T) Proxy.newProxyInstance(QuiltLauncherBase.getLauncher().getTargetClassLoader(), new Class[] { type }, new InvocationHandler() {
+			@SuppressWarnings("unchecked")
+			T tmp = (T) Proxy.newProxyInstance(QuiltLauncherBase.getLauncher().getTargetClassLoader(), new Class[] { type }, new InvocationHandler() {
 				@Override
 				public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
 					return targetMethod.invoke(targetObject, args);
 				}
 			});
+			return tmp;
 		}
 	}
 }

--- a/src/main/java/org/quiltmc/loader/impl/util/UrlConversionException.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/UrlConversionException.java
@@ -16,6 +16,7 @@
 
 package org.quiltmc.loader.impl.util;
 
+@SuppressWarnings("serial")
 public class UrlConversionException extends Exception {
 	public UrlConversionException() {
 		super();

--- a/src/main/java/org/quiltmc/loader/impl/util/version/VersionParsingException.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/version/VersionParsingException.java
@@ -17,6 +17,7 @@
 package org.quiltmc.loader.impl.util.version;
 
 /** @deprecated Replaced by {@link net.fabricmc.loader.api.VersionParsingException} */
+@SuppressWarnings("serial")
 @Deprecated
 public class VersionParsingException extends Exception {
 	public VersionParsingException() {


### PR DESCRIPTION
There are quite a few compiler warnings, most of them trivial things like rawtypes, unneeded `@SuppressWarnings` annotations, unchecked casts, and missing `serialVersionUID`. This fixes the rawtypes, properly suppresses the unchecked casts rather than only suppressing them in IDEA, suppresses the `serialVersionUID` complaints since we don't use `Serializable` anyway, removes some unused private methods and constructors, and moves away from using deprecated code where possible and suppresses the deprecation warning where it makes sense to do so (usually for things that are either for support of deprecated things or when the `@Deprecated` is because it's internal rather than because it's deprecated.)