### PR TITLE
Allow for customizing the mods and config folder with VM args

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -120,27 +120,13 @@ public class QuiltLoaderImpl implements FabricLoader {
 	private void setGameDir(Path gameDir) {
 		this.gameDir = gameDir;
 		String configDir = System.getProperty(SystemProperties.CONFIG_DIRECTORY);
-		this.configDir = resolveIfNotAbsolute(gameDir, configDir == null || configDir.isEmpty()  ? "config" : configDir);
+		this.configDir = gameDir.resolve(configDir == null || configDir.isEmpty()  ? "config" : configDir);
 		refreshModsDir(gameDir);
 	}
 
 	private void refreshModsDir(Path gameDir) {
 		String modsSubDir = System.getProperty(SystemProperties.MODS_DIRECTORY);
-		this.modsDir = resolveIfNotAbsolute(gameDir, modsSubDir == null || modsSubDir.isEmpty() ? "mods" : modsSubDir);
-	}
-
-	/**
-	 * If the passed string toResolve is an absolute path, it will be
-	 * returned as a path. If it is not absolute, it will be returned
-	 * as a subdirectory of the passed rootDir.
-	 *
-	 * @param rootDir The parent directory to use if toResolve is not absolute
-	 * @param toResolve The subdirectory/absolute path to be interpreted
-	 * @return Either a path leading to a subdirectory of rootDir, or an absolute path
-	 */
-	private Path resolveIfNotAbsolute(Path rootDir, String toResolve) {
-		Path abs = Paths.get(toResolve);
-		return abs.isAbsolute() ? abs : rootDir.resolve(toResolve);
+		this.modsDir = gameDir.resolve(modsSubDir == null || modsSubDir.isEmpty() ? "mods" : modsSubDir);
 	}
 
 	@Override

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -119,8 +119,8 @@ public class QuiltLoaderImpl implements FabricLoader {
 
 	private void setGameDir(Path gameDir) {
 		this.gameDir = gameDir;
-		String configSubDir = System.getProperty(SystemProperties.CONFIG_SUBDIRECTORY);
-		this.configDir = resolveIfNotAbsolute(gameDir, configSubDir == null || configSubDir.isEmpty()  ? "config" : configSubDir);
+		String configDir = System.getProperty(SystemProperties.CONFIG_DIRECTORY);
+		this.configDir = resolveIfNotAbsolute(gameDir, configDir == null || configDir.isEmpty()  ? "config" : configDir);
 		refreshModsDir(gameDir);
 	}
 

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -16,51 +16,38 @@
 
 package org.quiltmc.loader.impl;
 
+import net.fabricmc.accesswidener.AccessWidener;
+import net.fabricmc.accesswidener.AccessWidenerReader;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.LanguageAdapter;
+import net.fabricmc.loader.api.MappingResolver;
+import net.fabricmc.loader.api.SemanticVersion;
+import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.ApiStatus;
+import org.objectweb.asm.Opcodes;
+import org.quiltmc.loader.impl.discovery.*;
+import org.quiltmc.loader.impl.game.GameProvider;
+import org.quiltmc.loader.impl.gui.QuiltGuiEntry;
+import org.quiltmc.loader.impl.launch.common.QuiltLauncher;
+import org.quiltmc.loader.impl.launch.common.QuiltLauncherBase;
+import org.quiltmc.loader.impl.launch.knot.Knot;
+import org.quiltmc.loader.impl.metadata.DependencyOverrides;
+import org.quiltmc.loader.impl.metadata.EntrypointMetadata;
+import org.quiltmc.loader.impl.metadata.LoaderModMetadata;
+import org.quiltmc.loader.impl.util.DefaultLanguageAdapter;
+import org.quiltmc.loader.impl.util.SystemProperties;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
-import net.fabricmc.loader.api.FabricLoader;
-import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
-import org.jetbrains.annotations.ApiStatus;
-import org.quiltmc.loader.impl.discovery.RuntimeModRemapper;
-import org.quiltmc.loader.impl.metadata.DependencyOverrides;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import net.fabricmc.api.EnvType;
-import net.fabricmc.loader.api.LanguageAdapter;
-import net.fabricmc.loader.api.MappingResolver;
-import net.fabricmc.loader.api.SemanticVersion;
-import org.quiltmc.loader.impl.discovery.ClasspathModCandidateFinder;
-import org.quiltmc.loader.impl.discovery.DirectoryModCandidateFinder;
-import org.quiltmc.loader.impl.discovery.ModCandidate;
-import org.quiltmc.loader.impl.discovery.ModResolutionException;
-import org.quiltmc.loader.impl.discovery.ModResolver;
-import org.quiltmc.loader.impl.game.GameProvider;
-import org.quiltmc.loader.impl.gui.QuiltGuiEntry;
-import org.quiltmc.loader.impl.launch.common.QuiltLauncher;
-import org.quiltmc.loader.impl.launch.common.QuiltLauncherBase;
-import org.quiltmc.loader.impl.launch.knot.Knot;
-import org.quiltmc.loader.impl.metadata.EntrypointMetadata;
-import org.quiltmc.loader.impl.metadata.LoaderModMetadata;
-import org.quiltmc.loader.impl.util.DefaultLanguageAdapter;
-import org.quiltmc.loader.impl.util.SystemProperties;
-import net.fabricmc.accesswidener.AccessWidener;
-import net.fabricmc.accesswidener.AccessWidenerReader;
-
-import org.objectweb.asm.Opcodes;
 
 /**
  * The main class for mod loading operations.

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -55,6 +55,7 @@ import org.quiltmc.loader.impl.launch.knot.Knot;
 import org.quiltmc.loader.impl.metadata.EntrypointMetadata;
 import org.quiltmc.loader.impl.metadata.LoaderModMetadata;
 import org.quiltmc.loader.impl.util.DefaultLanguageAdapter;
+import org.quiltmc.loader.impl.util.StringUtil;
 import org.quiltmc.loader.impl.util.SystemProperties;
 import net.fabricmc.accesswidener.AccessWidener;
 import net.fabricmc.accesswidener.AccessWidenerReader;
@@ -71,6 +72,9 @@ public class QuiltLoaderImpl implements FabricLoader {
 	public static final int ASM_VERSION = Opcodes.ASM9;
 
 	protected static Logger LOGGER = LogManager.getFormatterLogger("Quilt|Loader");
+
+	public static final String DEFAULT_MODS_DIR = "mods";
+	public static final String DEFAULT_CONFIG_DIR = "config";
 
 	protected final Map<String, ModContainer> modMap = new HashMap<>();
 	protected List<ModContainer> mods = new ArrayList<>();
@@ -119,13 +123,13 @@ public class QuiltLoaderImpl implements FabricLoader {
 	private void setGameDir(Path gameDir) {
 		this.gameDir = gameDir;
 		String configDir = System.getProperty(SystemProperties.CONFIG_DIRECTORY);
-		this.configDir = gameDir.resolve(configDir == null || configDir.isEmpty()  ? "config" : configDir);
+		this.configDir = gameDir.resolve(StringUtil.either(configDir, DEFAULT_CONFIG_DIR));
 		refreshModsDir(gameDir);
 	}
 
 	private void refreshModsDir(Path gameDir) {
-		String modsSubDir = System.getProperty(SystemProperties.MODS_DIRECTORY);
-		this.modsDir = gameDir.resolve(modsSubDir == null || modsSubDir.isEmpty() ? "mods" : modsSubDir);
+		String modsDir = System.getProperty(SystemProperties.MODS_DIRECTORY);
+		this.modsDir = gameDir.resolve(StringUtil.either(modsDir, DEFAULT_MODS_DIR));
 	}
 
 	@Override

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -118,14 +118,14 @@ public class QuiltLoaderImpl implements FabricLoader {
 
 	private void setGameDir(Path gameDir) {
 		this.gameDir = gameDir;
-		String configSubDir = System.getProperty("quilt.configSubDir");
-		this.configDir = gameDir.resolve(configSubDir == null ? "config" : configSubDir);
+		String configSubDir = System.getProperty(SystemProperties.CONFIG_SUBDIRECTORY);
+		this.configDir = gameDir.resolve(configSubDir == null || configSubDir.isEmpty()  ? "config" : configSubDir);
 		refreshModDir(gameDir);
 	}
 
 	private void refreshModDir(Path gameDir) {
-		String modSubDir = System.getProperty("quilt.modSubDir");
-		this.modDir = gameDir.resolve(modSubDir == null ? "mods" : modSubDir);
+		String modSubDir = System.getProperty(SystemProperties.MOD_SUBDIRECTORY);
+		this.modDir = gameDir.resolve(modSubDir == null || modSubDir.isEmpty() ? "mods" : modSubDir);
 	}
 
 	@Override
@@ -167,7 +167,7 @@ public class QuiltLoaderImpl implements FabricLoader {
 			try {
 				Files.createDirectories(configDir);
 			} catch (IOException e) {
-				throw new RuntimeException("Creating config directory", e);
+				throw new RuntimeException("Failed to create config directory", e);
 			}
 		}
 		return configDir;
@@ -189,7 +189,7 @@ public class QuiltLoaderImpl implements FabricLoader {
 			try {
 				Files.createDirectories(modDir);
 			} catch (IOException e) {
-				throw new RuntimeException("Creating mods directory", e);
+				throw new RuntimeException("Failed to create mods directory", e);
 			}
 		}
 		return modDir;

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -87,7 +88,7 @@ public class QuiltLoaderImpl implements FabricLoader {
 	private GameProvider provider;
 	private Path gameDir;
 	private Path configDir;
-	private Path modDir;
+	private Path modsDir;
 
 	protected QuiltLoaderImpl() {
 	}
@@ -119,13 +120,27 @@ public class QuiltLoaderImpl implements FabricLoader {
 	private void setGameDir(Path gameDir) {
 		this.gameDir = gameDir;
 		String configSubDir = System.getProperty(SystemProperties.CONFIG_SUBDIRECTORY);
-		this.configDir = gameDir.resolve(configSubDir == null || configSubDir.isEmpty()  ? "config" : configSubDir);
-		refreshModDir(gameDir);
+		this.configDir = resolveIfNotAbsolute(gameDir, configSubDir == null || configSubDir.isEmpty()  ? "config" : configSubDir);
+		refreshModsDir(gameDir);
 	}
 
-	private void refreshModDir(Path gameDir) {
-		String modSubDir = System.getProperty(SystemProperties.MOD_SUBDIRECTORY);
-		this.modDir = gameDir.resolve(modSubDir == null || modSubDir.isEmpty() ? "mods" : modSubDir);
+	private void refreshModsDir(Path gameDir) {
+		String modsSubDir = System.getProperty(SystemProperties.MODS_DIRECTORY);
+		this.modsDir = resolveIfNotAbsolute(gameDir, modsSubDir == null || modsSubDir.isEmpty() ? "mods" : modsSubDir);
+	}
+
+	/**
+	 * If the passed string toResolve is an absolute path, it will be
+	 * returned as a path. If it is not absolute, it will be returned
+	 * as a subdirectory of the passed rootDir.
+	 *
+	 * @param rootDir The parent directory to use if toResolve is not absolute
+	 * @param toResolve The subdirectory/absolute path to be interpreted
+	 * @return Either a path leading to a subdirectory of rootDir, or an absolute path
+	 */
+	private Path resolveIfNotAbsolute(Path rootDir, String toResolve) {
+		Path abs = Paths.get(toResolve);
+		return abs.isAbsolute() ? abs : rootDir.resolve(toResolve);
 	}
 
 	@Override
@@ -180,19 +195,19 @@ public class QuiltLoaderImpl implements FabricLoader {
 	}
 
 	public Path getModsDir() {
-		if (modDir == null) {
+		if (modsDir == null) {
 			// Should not be null ever
-			refreshModDir(gameDir);
+			refreshModsDir(gameDir);
 		}
 
-		if (!Files.exists(modDir)) {
+		if (!Files.exists(modsDir)) {
 			try {
-				Files.createDirectories(modDir);
+				Files.createDirectories(modsDir);
 			} catch (IOException e) {
 				throw new RuntimeException("Failed to create mods directory", e);
 			}
 		}
-		return modDir;
+		return modsDir;
 	}
 
 	@Deprecated

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -16,38 +16,50 @@
 
 package org.quiltmc.loader.impl;
 
-import net.fabricmc.accesswidener.AccessWidener;
-import net.fabricmc.accesswidener.AccessWidenerReader;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.loader.api.FabricLoader;
-import net.fabricmc.loader.api.LanguageAdapter;
-import net.fabricmc.loader.api.MappingResolver;
-import net.fabricmc.loader.api.SemanticVersion;
-import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.ApiStatus;
-import org.objectweb.asm.Opcodes;
-import org.quiltmc.loader.impl.discovery.*;
-import org.quiltmc.loader.impl.game.GameProvider;
-import org.quiltmc.loader.impl.gui.QuiltGuiEntry;
-import org.quiltmc.loader.impl.launch.common.QuiltLauncher;
-import org.quiltmc.loader.impl.launch.common.QuiltLauncherBase;
-import org.quiltmc.loader.impl.launch.knot.Knot;
-import org.quiltmc.loader.impl.metadata.DependencyOverrides;
-import org.quiltmc.loader.impl.metadata.EntrypointMetadata;
-import org.quiltmc.loader.impl.metadata.LoaderModMetadata;
-import org.quiltmc.loader.impl.util.DefaultLanguageAdapter;
-import org.quiltmc.loader.impl.util.SystemProperties;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
+import org.jetbrains.annotations.ApiStatus;
+import org.quiltmc.loader.impl.discovery.RuntimeModRemapper;
+import org.quiltmc.loader.impl.metadata.DependencyOverrides;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.api.LanguageAdapter;
+import net.fabricmc.loader.api.MappingResolver;
+import net.fabricmc.loader.api.SemanticVersion;
+import org.quiltmc.loader.impl.discovery.ClasspathModCandidateFinder;
+import org.quiltmc.loader.impl.discovery.DirectoryModCandidateFinder;
+import org.quiltmc.loader.impl.discovery.ModCandidate;
+import org.quiltmc.loader.impl.discovery.ModResolutionException;
+import org.quiltmc.loader.impl.discovery.ModResolver;
+import org.quiltmc.loader.impl.game.GameProvider;
+import org.quiltmc.loader.impl.gui.QuiltGuiEntry;
+import org.quiltmc.loader.impl.launch.common.QuiltLauncher;
+import org.quiltmc.loader.impl.launch.common.QuiltLauncherBase;
+import org.quiltmc.loader.impl.launch.knot.Knot;
+import org.quiltmc.loader.impl.metadata.EntrypointMetadata;
+import org.quiltmc.loader.impl.metadata.LoaderModMetadata;
+import org.quiltmc.loader.impl.util.DefaultLanguageAdapter;
+import org.quiltmc.loader.impl.util.SystemProperties;
+import net.fabricmc.accesswidener.AccessWidener;
+import net.fabricmc.accesswidener.AccessWidenerReader;
+
+import org.objectweb.asm.Opcodes;
 
 /**
  * The main class for mod loading operations.

--- a/src/main/java/org/quiltmc/loader/impl/util/StringUtil.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/StringUtil.java
@@ -16,9 +16,6 @@
 
 package org.quiltmc.loader.impl.util;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 public final class StringUtil {
 	private StringUtil() {
 
@@ -31,9 +28,5 @@ public final class StringUtil {
 		} else {
 			return new String[] { defaultNamespace, s };
 		}
-	}
-
-	public static String either(@Nullable String candidate, @NotNull String orElse) {
-		return (candidate == null || candidate.isEmpty()) ? orElse : candidate;
 	}
 }

--- a/src/main/java/org/quiltmc/loader/impl/util/StringUtil.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/StringUtil.java
@@ -16,6 +16,9 @@
 
 package org.quiltmc.loader.impl.util;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 public final class StringUtil {
 	private StringUtil() {
 
@@ -28,5 +31,9 @@ public final class StringUtil {
 		} else {
 			return new String[] { defaultNamespace, s };
 		}
+	}
+
+	public static String either(@Nullable String candidate, @NotNull String orElse) {
+		return (candidate == null || candidate.isEmpty()) ? orElse : candidate;
 	}
 }

--- a/src/main/java/org/quiltmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/SystemProperties.java
@@ -24,8 +24,8 @@ public final class SystemProperties {
 	public static final String REMAP_CLASSPATH_FILE = "quilt.remapClasspathFile";
 	public static final String LAUNCHER_NAME = "quilt.launcherName";
 	public static final String DEBUG_MOD_RESOLVING = "quilt.debug.mod_resolving";
-	public static final String MOD_SUBDIRECTORY = "quilt.modSubDir";
-	public static final String CONFIG_SUBDIRECTORY = "quilt.configSubDir";
+	public static final String MODS_DIRECTORY = "quilt.modsDir";
+	public static final String CONFIG_SUBDIRECTORY = "quilt.configDir";
 
 	private SystemProperties() {
 	}

--- a/src/main/java/org/quiltmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/SystemProperties.java
@@ -24,6 +24,8 @@ public final class SystemProperties {
 	public static final String REMAP_CLASSPATH_FILE = "quilt.remapClasspathFile";
 	public static final String LAUNCHER_NAME = "quilt.launcherName";
 	public static final String DEBUG_MOD_RESOLVING = "quilt.debug.mod_resolving";
+	public static final String MOD_SUBDIRECTORY = "quilt.modSubDir";
+	public static final String CONFIG_SUBDIRECTORY = "quilt.configSubDir";
 
 	private SystemProperties() {
 	}

--- a/src/main/java/org/quiltmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/SystemProperties.java
@@ -25,7 +25,7 @@ public final class SystemProperties {
 	public static final String LAUNCHER_NAME = "quilt.launcherName";
 	public static final String DEBUG_MOD_RESOLVING = "quilt.debug.mod_resolving";
 	public static final String MODS_DIRECTORY = "quilt.modsDir";
-	public static final String CONFIG_SUBDIRECTORY = "quilt.configDir";
+	public static final String CONFIG_DIRECTORY = "quilt.configDir";
 
 	private SystemProperties() {
 	}


### PR DESCRIPTION
This PR lets you change the subfolders (within the current game directory) from which mods and mod configuration files are loaded.
The arguments are as follows:
`-Dquilt.modsDir=path/to/mods`
`-Dquilt.configDir=path/to/config`