### PR TITLE
Make ModResolver.resolve return ModResolveResult

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ out/
 .classpath
 .project
 .settings/
+*.launch
 
 ## vscode
 .vscode/

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -47,6 +47,7 @@ import org.quiltmc.loader.impl.discovery.DirectoryModCandidateFinder;
 import org.quiltmc.loader.impl.discovery.ModCandidate;
 import org.quiltmc.loader.impl.discovery.ModResolutionException;
 import org.quiltmc.loader.impl.discovery.ModResolver;
+import org.quiltmc.loader.impl.discovery.ModResolver.ModResolveResult;
 import org.quiltmc.loader.impl.game.GameProvider;
 import org.quiltmc.loader.impl.gui.QuiltGuiEntry;
 import org.quiltmc.loader.impl.launch.common.QuiltLauncher;
@@ -218,7 +219,8 @@ public class QuiltLoaderImpl implements FabricLoader {
 		ModResolver resolver = new ModResolver();
 		resolver.addCandidateFinder(new ClasspathModCandidateFinder());
 		resolver.addCandidateFinder(new DirectoryModCandidateFinder(getModsDir(), isDevelopmentEnvironment()));
-		Map<String, ModCandidate> candidateMap = resolver.resolve(this);
+		ModResolveResult result = resolver.resolve(this);
+		Map<String, ModCandidate> candidateMap = result.modMap;
 
 		String modText;
 		switch (candidateMap.values().size()) {


### PR DESCRIPTION
This makes it possible to validate provided mods in the tests, and makes it *very slightly* easier to add more data to the result (perhaps custom `ModLink`s or `LoadOption`s for loader plugins, or possibly explanations for *why* a given mod candidate was or was not chosen - either need lots more work to actually implement).