### PR TITLE
Add OverridenModIdDefintion to ModLink.LINK_ORDER

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/discovery/ModResolver.java
+++ b/src/main/java/org/quiltmc/loader/impl/discovery/ModResolver.java
@@ -1332,6 +1332,7 @@ public class ModResolver {
 		static {
 			LINK_ORDER.add(MandatoryModIdDefinition.class);
 			LINK_ORDER.add(OptionalModIdDefintion.class);
+			LINK_ORDER.add(OverridenModIdDefintion.class);
 			LINK_ORDER.add(ModDep.class);
 			LINK_ORDER.add(ModBreakage.class);
 		}


### PR DESCRIPTION
I must have missed this one when I contributed this... woops.

This is just a simple bugfix and should be merged ASAP.