### PR TITLE
Deprecate fabric's metadata, and add quilt's equivilent metadata.

### DIFF
--- a/minecraft-test/src/main/java/org/quiltmc/test/EntrypointTester.java
+++ b/minecraft-test/src/main/java/org/quiltmc/test/EntrypointTester.java
@@ -16,20 +16,21 @@
 
 package org.quiltmc.test;
 
-import net.fabricmc.api.ModInitializer;
-import net.fabricmc.loader.api.FabricLoader;
-
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.quiltmc.loader.api.ModContainer;
+import org.quiltmc.loader.api.ModInitializer;
+import org.quiltmc.loader.api.QuiltLoader;
 
 public class EntrypointTester implements ModInitializer {
 
 
 	@Override
-	public void onInitialize() {
+	public void onInitialize(ModContainer mod) {
 
-		Set<CustomEntry> testingInits = new LinkedHashSet<>(FabricLoader.getInstance().getEntrypoints("test:testing", CustomEntry.class));
+		Set<CustomEntry> testingInits = new LinkedHashSet<>(QuiltLoader.getInstance().getEntrypoints("test:testing", CustomEntry.class));
 		System.out.printf("Found %s testing inits%n", testingInits.size());
 		System.out.println(testingInits.stream().map(CustomEntry::describe).collect(Collectors.joining(", ")));
 	}

--- a/minecraft-test/src/main/java/org/quiltmc/test/EntrypointTester.java
+++ b/minecraft-test/src/main/java/org/quiltmc/test/EntrypointTester.java
@@ -21,8 +21,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.quiltmc.loader.api.ModContainer;
-import org.quiltmc.loader.api.ModInitializer;
 import org.quiltmc.loader.api.QuiltLoader;
+import org.quiltmc.loader.api.minecraft.ModInitializer;
 
 public class EntrypointTester implements ModInitializer {
 

--- a/minecraft-test/src/main/java/org/quiltmc/test/EntrypointTester.java
+++ b/minecraft-test/src/main/java/org/quiltmc/test/EntrypointTester.java
@@ -30,7 +30,7 @@ public class EntrypointTester implements ModInitializer {
 	@Override
 	public void onInitialize(ModContainer mod) {
 
-		Set<CustomEntry> testingInits = new LinkedHashSet<>(QuiltLoader.getInstance().getEntrypoints("test:testing", CustomEntry.class));
+		Set<CustomEntry> testingInits = new LinkedHashSet<>(QuiltLoader.getEntrypoints("test:testing", CustomEntry.class));
 		System.out.printf("Found %s testing inits%n", testingInits.size());
 		System.out.println(testingInits.stream().map(CustomEntry::describe).collect(Collectors.joining(", ")));
 	}

--- a/minecraft-test/src/main/java/org/quiltmc/test/PrelaunchTest.java
+++ b/minecraft-test/src/main/java/org/quiltmc/test/PrelaunchTest.java
@@ -16,16 +16,16 @@
 
 package org.quiltmc.test;
 
+import org.quiltmc.loader.api.ModContainer;
+import org.quiltmc.loader.api.entrypoint.PreLaunchEntrypoint;
 import org.quiltmc.loader.impl.launch.common.QuiltLauncherBase;
-
-import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 
 /**
  * Test preLaunch entrypoint.
  */
 public final class PrelaunchTest implements PreLaunchEntrypoint {
 	@Override
-	public void onPreLaunch() {
+	public void onPreLaunch(ModContainer mod) {
 		if (TestMod.class.getClassLoader() != QuiltLauncherBase.getLauncher().getTargetClassLoader()) {
 			throw new IllegalStateException("Invalid class loader: " + TestMod.class.getClassLoader());
 		}

--- a/minecraft-test/src/main/java/org/quiltmc/test/TestMod.java
+++ b/minecraft-test/src/main/java/org/quiltmc/test/TestMod.java
@@ -17,7 +17,7 @@
 package org.quiltmc.test;
 
 import org.quiltmc.loader.api.ModContainer;
-import org.quiltmc.loader.api.ModInitializer;
+import org.quiltmc.loader.api.minecraft.ModInitializer;
 import org.quiltmc.loader.impl.launch.common.QuiltLauncherBase;
 
 /**

--- a/minecraft-test/src/main/java/org/quiltmc/test/TestMod.java
+++ b/minecraft-test/src/main/java/org/quiltmc/test/TestMod.java
@@ -16,16 +16,16 @@
 
 package org.quiltmc.test;
 
+import org.quiltmc.loader.api.ModContainer;
+import org.quiltmc.loader.api.ModInitializer;
 import org.quiltmc.loader.impl.launch.common.QuiltLauncherBase;
-
-import net.fabricmc.api.ModInitializer;
 
 /**
  * Test entrypoint for a mod.
  */
 public final class TestMod implements ModInitializer {
 	@Override
-	public void onInitialize() {
+	public void onInitialize(ModContainer mod) {
 		if (TestMod.class.getClassLoader() != QuiltLauncherBase.getLauncher().getTargetClassLoader()) {
 			throw new IllegalStateException("Invalid class loader: " + TestMod.class.getClassLoader());
 		}

--- a/src/main/java/net/fabricmc/api/ClientModInitializer.java
+++ b/src/main/java/net/fabricmc/api/ClientModInitializer.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.api;
 
+import org.quiltmc.loader.api.ModContainer;
+
 /**
  * A mod initializer ran only on {@link EnvType#CLIENT}.
  *
@@ -29,9 +31,14 @@ package net.fabricmc.api;
  * @see net.fabricmc.loader.api.FabricLoader#getEntrypointContainers(String, Class)
  */
 @FunctionalInterface
-public interface ClientModInitializer {
+public interface ClientModInitializer extends org.quiltmc.loader.api.minecraft.ClientModInitializer {
 	/**
 	 * Runs the mod initializer on the client environment.
 	 */
 	void onInitializeClient();
+
+	@Override
+	default void onInitializeClient(ModContainer mod) {
+		onInitializeClient();
+	}
 }

--- a/src/main/java/net/fabricmc/api/DedicatedServerModInitializer.java
+++ b/src/main/java/net/fabricmc/api/DedicatedServerModInitializer.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.api;
 
+import org.quiltmc.loader.api.ModContainer;
+
 /**
  * A mod initializer ran only on {@link EnvType#SERVER}.
  *
@@ -24,11 +26,18 @@ package net.fabricmc.api;
  * @see ModInitializer
  * @see ClientModInitializer
  * @see net.fabricmc.loader.api.FabricLoader#getEntrypointContainers(String, Class)
+ * @deprecated Please use quilt's version: {@link org.quiltmc.loader.api.minecraft.DedicatedServerModInitializer}
  */
+@Deprecated
 @FunctionalInterface
-public interface DedicatedServerModInitializer {
+public interface DedicatedServerModInitializer extends org.quiltmc.loader.api.minecraft.DedicatedServerModInitializer {
 	/**
 	 * Runs the mod initializer on the server environment.
 	 */
 	void onInitializeServer();
+
+	@Override
+	default void onInitializeServer(ModContainer mod) {
+		onInitializeServer();
+	}
 }

--- a/src/main/java/net/fabricmc/api/ModInitializer.java
+++ b/src/main/java/net/fabricmc/api/ModInitializer.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.api;
 
+import org.quiltmc.loader.api.ModContainer;
+
 /**
  * A mod initializer.
  *
@@ -24,11 +26,18 @@ package net.fabricmc.api;
  * @see ClientModInitializer
  * @see DedicatedServerModInitializer
  * @see net.fabricmc.loader.api.FabricLoader#getEntrypointContainers(String, Class)
+ * @deprecated Please migrate to the quilt version: {@link  org.quiltmc.loader.api.ModInitializer}.
  */
+@Deprecated
 @FunctionalInterface
-public interface ModInitializer {
+public interface ModInitializer extends org.quiltmc.loader.api.ModInitializer {
 	/**
 	 * Runs the mod initializer.
 	 */
 	void onInitialize();
+
+	@Override
+	default void onInitialize(ModContainer mod) {
+		onInitialize();
+	}
 }

--- a/src/main/java/net/fabricmc/api/ModInitializer.java
+++ b/src/main/java/net/fabricmc/api/ModInitializer.java
@@ -26,11 +26,11 @@ import org.quiltmc.loader.api.ModContainer;
  * @see ClientModInitializer
  * @see DedicatedServerModInitializer
  * @see net.fabricmc.loader.api.FabricLoader#getEntrypointContainers(String, Class)
- * @deprecated Please migrate to the quilt version: {@link  org.quiltmc.loader.api.ModInitializer}.
+ * @deprecated Please migrate to the quilt version: {@link  org.quiltmc.loader.api.minecraft.ModInitializer}.
  */
 @Deprecated
 @FunctionalInterface
-public interface ModInitializer extends org.quiltmc.loader.api.ModInitializer {
+public interface ModInitializer extends org.quiltmc.loader.api.minecraft.ModInitializer {
 	/**
 	 * Runs the mod initializer.
 	 */

--- a/src/main/java/net/fabricmc/loader/api/EntrypointException.java
+++ b/src/main/java/net/fabricmc/loader/api/EntrypointException.java
@@ -19,8 +19,10 @@ package net.fabricmc.loader.api;
 /**
  * Represents an exception that arises when obtaining entrypoints.
  * 
- * @see FabricLoader#getEntrypointContainers(String, Class) 
+ * @see FabricLoader#getEntrypointContainers(String, Class)
+ * @deprecated This is only thrown by the deprecated {@link FabricLoader}. 
  */
+@Deprecated
 @SuppressWarnings("serial")
 public class EntrypointException extends RuntimeException {
 	private final String key;

--- a/src/main/java/net/fabricmc/loader/api/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/api/FabricLoader.java
@@ -44,7 +44,7 @@ public interface FabricLoader {
 	 * Returns the public-facing Fabric Loader instance.
 	 */
 	static FabricLoader getInstance() {
-		return ((QuiltLoaderImpl) QuiltLoader.getInstance()).quilt2Fabric;
+		return Quilt2FabricLoader.INSTANCE;
 	}
 
 	/**

--- a/src/main/java/net/fabricmc/loader/api/FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/api/FabricLoader.java
@@ -28,6 +28,7 @@ import net.fabricmc.loader.impl.quiltmc.Quilt2FabricLoader;
 
 import org.jetbrains.annotations.Nullable;
 import org.quiltmc.loader.api.QuiltLoader;
+import org.quiltmc.loader.api.minecraft.MinecraftQuiltLoader;
 import org.quiltmc.loader.impl.QuiltLoaderImpl;
 
 /**
@@ -36,7 +37,7 @@ import org.quiltmc.loader.impl.QuiltLoaderImpl;
  * <p>To obtain a working instance, call {@link #getInstance()}.</p>
  *
  * @since 0.4.0
- * @deprecated Please migrate to using {@link QuiltLoader} directly instead.
+ * @deprecated Please migrate to using {@link QuiltLoader} directly instead - except for {@link #getEnvironmentType()}, which is now located in {@link MinecraftQuiltLoader}.
  */
 @Deprecated
 public interface FabricLoader {

--- a/src/main/java/net/fabricmc/loader/api/ModContainer.java
+++ b/src/main/java/net/fabricmc/loader/api/ModContainer.java
@@ -23,6 +23,7 @@ import net.fabricmc.loader.api.metadata.ModMetadata;
 /**
  * Represents a mod.
  */
+@Deprecated
 public interface ModContainer {
 	/**
 	 * Returns the metadata of this mod.

--- a/src/main/java/net/fabricmc/loader/api/entrypoint/EntrypointContainer.java
+++ b/src/main/java/net/fabricmc/loader/api/entrypoint/EntrypointContainer.java
@@ -22,8 +22,10 @@ import net.fabricmc.loader.api.ModContainer;
  * A container holding both an entrypoint instance and the {@link ModContainer} which has provided the entrypoint.
  *
  * @param <T> The type of the entrypoint
- * @see net.fabricmc.loader.api.FabricLoader#getEntrypointContainers(String, Class) 
+ * @see net.fabricmc.loader.api.FabricLoader#getEntrypointContainers(String, Class)
+ * @deprecated Please migrate to the quilt version: {@link org.quiltmc.loader.api.entrypoint.EntrypointContainer}. 
  */
+@Deprecated
 public interface EntrypointContainer<T> {
 	/**
 	 * Returns the entrypoint instance. It will be constructed the first time you call this method.

--- a/src/main/java/net/fabricmc/loader/api/entrypoint/PreLaunchEntrypoint.java
+++ b/src/main/java/net/fabricmc/loader/api/entrypoint/PreLaunchEntrypoint.java
@@ -16,6 +16,9 @@
 
 package net.fabricmc.loader.api.entrypoint;
 
+import org.quiltmc.loader.api.ModContainer;
+import org.quiltmc.loader.api.entrypoint.GameEntrypoint;
+
 /**
  * Entrypoint getting invoked just before launching the game.
  *
@@ -27,12 +30,19 @@ package net.fabricmc.loader.api.entrypoint;
  * <p>The entrypoint is exposed with {@code preLaunch} key in the mod json and runs for any environment. It usually
  * executes several seconds before the {@code main}/{@code client}/{@code server} entrypoints.
  * 
- * @see net.fabricmc.loader.api.FabricLoader#getEntrypointContainers(String, Class) 
+ * @see net.fabricmc.loader.api.FabricLoader#getEntrypointContainers(String, Class)
+ * @deprecated Please migrate to the Quilt version of this interface: {@link org.quiltmc.loader.api.entrypoint.PreLaunchEntrypoint} 
  */
+@Deprecated
 @FunctionalInterface
-public interface PreLaunchEntrypoint {
+public interface PreLaunchEntrypoint extends org.quiltmc.loader.api.entrypoint.PreLaunchEntrypoint {
 	/**
 	 * Runs the entrypoint.
 	 */
 	void onPreLaunch();
+
+	@Override
+	default void onPreLaunch(ModContainer mod) {
+		onPreLaunch();
+	}
 }

--- a/src/main/java/net/fabricmc/loader/api/metadata/ContactInformation.java
+++ b/src/main/java/net/fabricmc/loader/api/metadata/ContactInformation.java
@@ -22,7 +22,10 @@ import java.util.Optional;
 
 /**
  * Represents a contact information.
+ * 
+ * @deprecated Please use quilt's org.quiltmc.loader.api.ModMetadata instead.
  */
+@Deprecated
 public interface ContactInformation {
 	/**
 	 * An empty contact information.

--- a/src/main/java/net/fabricmc/loader/api/metadata/CustomValue.java
+++ b/src/main/java/net/fabricmc/loader/api/metadata/CustomValue.java
@@ -20,7 +20,10 @@ import java.util.Map;
 
 /**
  * Represents a custom value in the {@code fabric.mod.json}.
+ 
+ * @deprecated Please use quilt's org.quiltmc.loader.api.ModMetadata instead.
  */
+@Deprecated
 public interface CustomValue {
 	/**
 	 * Returns the type of the value.

--- a/src/main/java/net/fabricmc/loader/api/metadata/ModDependency.java
+++ b/src/main/java/net/fabricmc/loader/api/metadata/ModDependency.java
@@ -23,7 +23,9 @@ import net.fabricmc.loader.api.VersionPredicate;
 
 /**
  * Represents a dependency.
+ * @deprecated Please use quilt's org.quiltmc.loader.api.ModMetadata instead.
  */
+@Deprecated
 public interface ModDependency {
 	/**
 	 * Returns the ID of the mod to check.

--- a/src/main/java/net/fabricmc/loader/api/metadata/ModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/api/metadata/ModMetadata.java
@@ -31,7 +31,10 @@ import net.fabricmc.loader.api.Version;
 
 /**
  * The metadata of a mod.
+ * 
+ * @deprecated Please use quilt's org.quiltmc.loader.api.ModMetadata instead.
  */
+@Deprecated
 public interface ModMetadata {
 	/**
 	 * Returns the type of the mod.

--- a/src/main/java/net/fabricmc/loader/api/metadata/Person.java
+++ b/src/main/java/net/fabricmc/loader/api/metadata/Person.java
@@ -18,7 +18,10 @@ package net.fabricmc.loader.api.metadata;
 
 /**
  * Represents a person.
+ * 
+ * @deprecated Please use quilt's org.quiltmc.loader.api.ModMetadata instead.
  */
+@Deprecated
 public interface Person {
 	/**
 	 * Returns the display name of the person.

--- a/src/main/java/net/fabricmc/loader/impl/quiltmc/Quilt2FabricEntrypointContainer.java
+++ b/src/main/java/net/fabricmc/loader/impl/quiltmc/Quilt2FabricEntrypointContainer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.loader.impl.quiltmc;
 
 import net.fabricmc.loader.api.ModContainer;

--- a/src/main/java/net/fabricmc/loader/impl/quiltmc/Quilt2FabricEntrypointContainer.java
+++ b/src/main/java/net/fabricmc/loader/impl/quiltmc/Quilt2FabricEntrypointContainer.java
@@ -1,0 +1,23 @@
+package net.fabricmc.loader.impl.quiltmc;
+
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
+
+public final class Quilt2FabricEntrypointContainer<T> implements EntrypointContainer<T> {
+
+	private final org.quiltmc.loader.api.entrypoint.EntrypointContainer<T> quilt;
+
+	public Quilt2FabricEntrypointContainer(org.quiltmc.loader.api.entrypoint.EntrypointContainer<T> quilt) {
+		this.quilt = quilt;
+	}
+
+	@Override
+	public T getEntrypoint() {
+		return quilt.getEntrypoint();
+	}
+
+	@Override
+	public ModContainer getProvider() {
+		return new Quilt2FabricModContainer(quilt.getProvider());
+	}
+}

--- a/src/main/java/net/fabricmc/loader/impl/quiltmc/Quilt2FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/impl/quiltmc/Quilt2FabricLoader.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import org.jetbrains.annotations.Nullable;
 import org.quiltmc.loader.api.QuiltLoader;
 import org.quiltmc.loader.api.entrypoint.EntrypointException;
+import org.quiltmc.loader.api.minecraft.MinecraftQuiltLoader;
 
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.MappingResolver;
@@ -36,21 +37,18 @@ import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
 import net.fabricmc.api.EnvType;
 
 public class Quilt2FabricLoader implements FabricLoader {
+	private Quilt2FabricLoader() {}
 
-	private final QuiltLoader quilt;
-
-	public Quilt2FabricLoader(QuiltLoader quilt) {
-		this.quilt = quilt;
-	}
+	public static final Quilt2FabricLoader INSTANCE = new Quilt2FabricLoader();
 
 	@Override
 	public <T> List<T> getEntrypoints(String key, Class<T> type) {
-		return quilt.getEntrypoints(key, type);
+		return QuiltLoader.getEntrypoints(key, type);
 	}
 
 	@Override
 	public <T> List<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type) {
-		List<org.quiltmc.loader.api.entrypoint.EntrypointContainer<T>> from = quilt.getEntrypointContainers(key, type);
+		List<org.quiltmc.loader.api.entrypoint.EntrypointContainer<T>> from = QuiltLoader.getEntrypointContainers(key, type);
 		List<EntrypointContainer<T>> out = new ArrayList<>(from.size());
 		try {
 			for (org.quiltmc.loader.api.entrypoint.EntrypointContainer<T> c : from) {
@@ -64,18 +62,18 @@ public class Quilt2FabricLoader implements FabricLoader {
 
 	@Override
 	public MappingResolver getMappingResolver() {
-		return new Quilt2FabricMappingResolver(quilt.getMappingResolver());
+		return new Quilt2FabricMappingResolver(QuiltLoader.getMappingResolver());
 	}
 
 	@Override
 	public Optional<ModContainer> getModContainer(String id) {
-		return quilt.getModContainer(id).map(Quilt2FabricModContainer::new);
+		return QuiltLoader.getModContainer(id).map(Quilt2FabricModContainer::new);
 	}
 
 	@Override
 	public Collection<ModContainer> getAllMods() {
 		Collection<ModContainer> out = new ArrayList<>();
-		for (org.quiltmc.loader.api.ModContainer mc : quilt.getAllMods()) {
+		for (org.quiltmc.loader.api.ModContainer mc : QuiltLoader.getAllMods()) {
 			out.add(new Quilt2FabricModContainer(mc));
 		}
 		return Collections.unmodifiableCollection(out);
@@ -83,27 +81,27 @@ public class Quilt2FabricLoader implements FabricLoader {
 
 	@Override
 	public boolean isModLoaded(String id) {
-		return quilt.isModLoaded(id);
+		return QuiltLoader.isModLoaded(id);
 	}
 
 	@Override
 	public boolean isDevelopmentEnvironment() {
-		return quilt.isDevelopmentEnvironment();
+		return QuiltLoader.isDevelopmentEnvironment();
 	}
 
 	@Override
 	public EnvType getEnvironmentType() {
-		return quilt.getEnvironmentType();
+		return MinecraftQuiltLoader.getEnvironmentType();
 	}
 
 	@Override
 	public @Nullable Object getGameInstance() {
-		return quilt.getGameInstance();
+		return QuiltLoader.getGameInstance();
 	}
 
 	@Override
 	public Path getGameDir() {
-		return quilt.getGameDir();
+		return QuiltLoader.getGameDir();
 	}
 
 	@Override
@@ -115,7 +113,7 @@ public class Quilt2FabricLoader implements FabricLoader {
 
 	@Override
 	public Path getConfigDir() {
-		return quilt.getConfigDir();
+		return QuiltLoader.getConfigDir();
 	}
 
 	@Override
@@ -127,6 +125,6 @@ public class Quilt2FabricLoader implements FabricLoader {
 
 	@Override
 	public String[] getLaunchArguments(boolean sanitize) {
-		return quilt.getLaunchArguments(sanitize);
+		return QuiltLoader.getLaunchArguments(sanitize);
 	}
 }

--- a/src/main/java/net/fabricmc/loader/impl/quiltmc/Quilt2FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/impl/quiltmc/Quilt2FabricLoader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.loader.impl.quiltmc;
 
 import java.io.File;

--- a/src/main/java/net/fabricmc/loader/impl/quiltmc/Quilt2FabricLoader.java
+++ b/src/main/java/net/fabricmc/loader/impl/quiltmc/Quilt2FabricLoader.java
@@ -1,0 +1,116 @@
+package net.fabricmc.loader.impl.quiltmc;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.jetbrains.annotations.Nullable;
+import org.quiltmc.loader.api.QuiltLoader;
+import org.quiltmc.loader.api.entrypoint.EntrypointException;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.MappingResolver;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
+
+import net.fabricmc.api.EnvType;
+
+public class Quilt2FabricLoader implements FabricLoader {
+
+	private final QuiltLoader quilt;
+
+	public Quilt2FabricLoader(QuiltLoader quilt) {
+		this.quilt = quilt;
+	}
+
+	@Override
+	public <T> List<T> getEntrypoints(String key, Class<T> type) {
+		return quilt.getEntrypoints(key, type);
+	}
+
+	@Override
+	public <T> List<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type) {
+		List<org.quiltmc.loader.api.entrypoint.EntrypointContainer<T>> from = quilt.getEntrypointContainers(key, type);
+		List<EntrypointContainer<T>> out = new ArrayList<>(from.size());
+		try {
+			for (org.quiltmc.loader.api.entrypoint.EntrypointContainer<T> c : from) {
+				out.add(new Quilt2FabricEntrypointContainer<>(c));
+			}
+			return out;
+		} catch (EntrypointException e) {
+			throw new net.fabricmc.loader.api.EntrypointException(e.getKey(), e);
+		}
+	}
+
+	@Override
+	public MappingResolver getMappingResolver() {
+		return new Quilt2FabricMappingResolver(quilt.getMappingResolver());
+	}
+
+	@Override
+	public Optional<ModContainer> getModContainer(String id) {
+		return quilt.getModContainer(id).map(Quilt2FabricModContainer::new);
+	}
+
+	@Override
+	public Collection<ModContainer> getAllMods() {
+		Collection<ModContainer> out = new ArrayList<>();
+		for (org.quiltmc.loader.api.ModContainer mc : quilt.getAllMods()) {
+			out.add(new Quilt2FabricModContainer(mc));
+		}
+		return Collections.unmodifiableCollection(out);
+	}
+
+	@Override
+	public boolean isModLoaded(String id) {
+		return quilt.isModLoaded(id);
+	}
+
+	@Override
+	public boolean isDevelopmentEnvironment() {
+		return quilt.isDevelopmentEnvironment();
+	}
+
+	@Override
+	public EnvType getEnvironmentType() {
+		return quilt.getEnvironmentType();
+	}
+
+	@Override
+	public @Nullable Object getGameInstance() {
+		return quilt.getGameInstance();
+	}
+
+	@Override
+	public Path getGameDir() {
+		return quilt.getGameDir();
+	}
+
+	@Override
+	@Deprecated
+	public File getGameDirectory() {
+		Path gameDir = getGameDir();
+		return gameDir == null ? null : gameDir.toFile();
+	}
+
+	@Override
+	public Path getConfigDir() {
+		return quilt.getConfigDir();
+	}
+
+	@Override
+	@Deprecated
+	public File getConfigDirectory() {
+		Path configDir = getConfigDir();
+		return configDir == null ? null : configDir.toFile();
+	}
+
+	@Override
+	public String[] getLaunchArguments(boolean sanitize) {
+		return quilt.getLaunchArguments(sanitize);
+	}
+}

--- a/src/main/java/net/fabricmc/loader/impl/quiltmc/Quilt2FabricMappingResolver.java
+++ b/src/main/java/net/fabricmc/loader/impl/quiltmc/Quilt2FabricMappingResolver.java
@@ -1,0 +1,43 @@
+package net.fabricmc.loader.impl.quiltmc;
+
+import java.util.Collection;
+
+import org.quiltmc.loader.api.MappingResolver;
+
+public class Quilt2FabricMappingResolver implements net.fabricmc.loader.api.MappingResolver {
+	private final MappingResolver quilt;
+
+	public Quilt2FabricMappingResolver(MappingResolver quilt) {
+		this.quilt = quilt;
+	}
+
+	@Override
+	public Collection<String> getNamespaces() {
+		return quilt.getNamespaces();
+	}
+
+	@Override
+	public String getCurrentRuntimeNamespace() {
+		return quilt.getCurrentRuntimeNamespace();
+	}
+
+	@Override
+	public String mapClassName(String namespace, String className) {
+		return quilt.mapClassName(namespace, className);
+	}
+
+	@Override
+	public String unmapClassName(String targetNamespace, String className) {
+		return quilt.unmapClassName(targetNamespace, className);
+	}
+
+	@Override
+	public String mapFieldName(String namespace, String owner, String name, String descriptor) {
+		return quilt.mapFieldName(namespace, owner, name, descriptor);
+	}
+
+	@Override
+	public String mapMethodName(String namespace, String owner, String name, String descriptor) {
+		return quilt.mapMethodName(namespace, owner, name, descriptor);
+	}
+}

--- a/src/main/java/net/fabricmc/loader/impl/quiltmc/Quilt2FabricMappingResolver.java
+++ b/src/main/java/net/fabricmc/loader/impl/quiltmc/Quilt2FabricMappingResolver.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.loader.impl.quiltmc;
 
 import java.util.Collection;

--- a/src/main/java/net/fabricmc/loader/impl/quiltmc/Quilt2FabricModContainer.java
+++ b/src/main/java/net/fabricmc/loader/impl/quiltmc/Quilt2FabricModContainer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.loader.impl.quiltmc;
 
 import java.nio.file.Path;

--- a/src/main/java/net/fabricmc/loader/impl/quiltmc/Quilt2FabricModContainer.java
+++ b/src/main/java/net/fabricmc/loader/impl/quiltmc/Quilt2FabricModContainer.java
@@ -1,0 +1,27 @@
+package net.fabricmc.loader.impl.quiltmc;
+
+import java.nio.file.Path;
+
+import org.quiltmc.loader.api.ModContainer;
+import org.quiltmc.loader.impl.metadata.qmj.ConvertibleModMetadata;
+import org.quiltmc.loader.impl.metadata.qmj.InternalModMetadata;
+
+import net.fabricmc.loader.api.metadata.ModMetadata;
+
+public final class Quilt2FabricModContainer implements net.fabricmc.loader.api.ModContainer {
+	private final ModContainer quilt;
+
+	public Quilt2FabricModContainer(ModContainer quilt) {
+		this.quilt = quilt;
+	}
+
+	@Override
+	public ModMetadata getMetadata() {
+		return ((ConvertibleModMetadata) quilt.metadata()).asFabricModMetadata();
+	}
+
+	@Override
+	public Path getRootPath() {
+		return quilt.rootPath();
+	}
+}

--- a/src/main/java/org/quiltmc/loader/api/LanguageAdapter.java
+++ b/src/main/java/org/quiltmc/loader/api/LanguageAdapter.java
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-package net.fabricmc.loader.api;
-
-import net.fabricmc.loader.impl.quiltmc.Quilt2FabricModContainer;
+package org.quiltmc.loader.api;
 
 /**
  * Creates instances of objects from custom notations.
@@ -94,11 +92,8 @@ import net.fabricmc.loader.impl.quiltmc.Quilt2FabricModContainer;
  *   You would declare {@code "net.fabricmc.example.ExampleMod::init"}.</p>
  *   </li>
  * </ul>
- * 
- * @deprecated Please move to quilt's {@link org.quiltmc.loader.api.LanguageAdapter}.
  */
-@Deprecated
-public interface LanguageAdapter extends org.quiltmc.loader.api.LanguageAdapter {
+public interface LanguageAdapter {
 	/**
 	 * Creates an object of {@code type} from an arbitrary string declaration.
 	 *
@@ -110,15 +105,4 @@ public interface LanguageAdapter extends org.quiltmc.loader.api.LanguageAdapter 
 	 * @throws LanguageAdapterException if a problem arises during creation, such as an invalid declaration
 	 */
 	<T> T create(ModContainer mod, String value, Class<T> type) throws LanguageAdapterException;
-
-	@Override
-	default <T> T create(org.quiltmc.loader.api.ModContainer mod, String value, Class<T> type)
-		throws org.quiltmc.loader.api.LanguageAdapterException {
-
-		try {
-			return create(new Quilt2FabricModContainer(mod), value, type);
-		} catch (LanguageAdapterException e) {
-			throw new org.quiltmc.loader.api.LanguageAdapterException(e);
-		}
-	}
 }

--- a/src/main/java/org/quiltmc/loader/api/LanguageAdapterException.java
+++ b/src/main/java/org/quiltmc/loader/api/LanguageAdapterException.java
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-package net.fabricmc.loader.api;
+package org.quiltmc.loader.api;
 
 /**
  * An exception that occurs during a {@link LanguageAdapter}'s object creation.
  *
  * @see LanguageAdapter
- * @deprecated Only thrown by fabric's {@link LanguageAdapter}, not quilt's.
  */
 @SuppressWarnings("serial")
-@Deprecated
 public class LanguageAdapterException extends Exception {
 	/**
 	 * Creates a new language adapter exception.

--- a/src/main/java/org/quiltmc/loader/api/MappingResolver.java
+++ b/src/main/java/org/quiltmc/loader/api/MappingResolver.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package net.fabricmc.loader.api;
+package org.quiltmc.loader.api;
 
 import java.util.Collection;
 
@@ -29,9 +29,7 @@ import java.util.Collection;
  * such as {@code "mypackage.MyClass$Inner"}.</p>
  *
  * @since 0.4.1
- * @deprecated Please migrate to the quilt version {@link org.quiltmc.loader.api.MappingResolver}
  */
-@Deprecated
 public interface MappingResolver {
 	/**
 	 * Get the list of all available mapping namespaces in the loaded instance.

--- a/src/main/java/org/quiltmc/loader/api/ModContainer.java
+++ b/src/main/java/org/quiltmc/loader/api/ModContainer.java
@@ -1,0 +1,30 @@
+package org.quiltmc.loader.api;
+
+import java.nio.file.Path;
+
+public interface ModContainer {
+
+	ModMetadata metadata();
+
+	/**
+	 * Returns the root directory of the mod.
+	 * 
+	 * <p>It may be the root directory of the mod JAR or the folder of the mod.</p>
+	 *
+	 * @return the root directory of the mod
+	 */
+	Path rootPath();
+
+	/**
+	 * Gets an NIO reference to a file inside the JAR.
+	 * 
+	 * <p>The path is not guaranteed to exist!</p>
+	 *
+	 * @param file The location from root, using {@code /} as a separator.
+	 * @return the path to a given file
+	 */
+	default Path getPath(String file) {
+		Path root = rootPath();
+		return root.resolve(file.replace("/", root.getFileSystem().getSeparator()));
+	}
+}

--- a/src/main/java/org/quiltmc/loader/api/ModContainer.java
+++ b/src/main/java/org/quiltmc/loader/api/ModContainer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.loader.api;
 
 import java.nio.file.Path;

--- a/src/main/java/org/quiltmc/loader/api/ModInitializer.java
+++ b/src/main/java/org/quiltmc/loader/api/ModInitializer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.loader.api;
 
 /**

--- a/src/main/java/org/quiltmc/loader/api/ModInitializer.java
+++ b/src/main/java/org/quiltmc/loader/api/ModInitializer.java
@@ -1,0 +1,15 @@
+package org.quiltmc.loader.api;
+
+/**
+ * A mod initializer.
+ *
+ * <p>In {@code quilt.mod.json}, the entrypoint is defined with {@code main} key.</p>
+ *
+ * @see ClientModInitializer
+ * @see DedicatedServerModInitializer
+ * @see org.quiltmc.loader.api.QuiltLoader#getEntrypointContainers(String, Class)
+ */
+@FunctionalInterface
+public interface ModInitializer {
+	void onInitialize(ModContainer mod);
+}

--- a/src/main/java/org/quiltmc/loader/api/QuiltLoader.java
+++ b/src/main/java/org/quiltmc/loader/api/QuiltLoader.java
@@ -1,34 +1,18 @@
-/*
- * Copyright 2016 FabricMC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+package org.quiltmc.loader.api;
 
-package net.fabricmc.loader.api;
-
-import java.io.File;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
-import net.fabricmc.loader.impl.quiltmc.Quilt2FabricLoader;
-
 import org.jetbrains.annotations.Nullable;
-import org.quiltmc.loader.api.QuiltLoader;
+import org.quiltmc.loader.api.entrypoint.EntrypointContainer;
 import org.quiltmc.loader.impl.QuiltLoaderImpl;
+
+import net.fabricmc.loader.api.EntrypointException;
+import net.fabricmc.loader.api.LanguageAdapter;
+
+import net.fabricmc.api.EnvType;
 
 /**
  * The public-facing FabricLoader instance.
@@ -36,15 +20,17 @@ import org.quiltmc.loader.impl.QuiltLoaderImpl;
  * <p>To obtain a working instance, call {@link #getInstance()}.</p>
  *
  * @since 0.4.0
- * @deprecated Please migrate to using {@link QuiltLoader} directly instead.
  */
-@Deprecated
-public interface FabricLoader {
+public interface QuiltLoader {
 	/**
-	 * Returns the public-facing Fabric Loader instance.
+	 * Returns the public-facing Quilt Loader instance.
 	 */
-	static FabricLoader getInstance() {
-		return ((QuiltLoaderImpl) QuiltLoader.getInstance()).quilt2Fabric;
+	static QuiltLoader getInstance() {
+		if (QuiltLoaderImpl.INSTANCE == null) {
+			throw new RuntimeException("Accessed QuiltLoader too early!");
+		}
+
+		return QuiltLoaderImpl.INSTANCE;
 	}
 
 	/**
@@ -173,18 +159,12 @@ public interface FabricLoader {
 	 */
 	Path getGameDir();
 
-	@Deprecated
-	File getGameDirectory();
-
 	/**
 	 * Get the current directory for game configuration files.
 	 *
 	 * @return the configuration directory
 	 */
 	Path getConfigDir();
-
-	@Deprecated
-	File getConfigDirectory();
 
 	/**
 	 * Gets the command line arguments used to launch the game. If this is printed for debugging, make sure {@code sanitize} is {@code true}.

--- a/src/main/java/org/quiltmc/loader/api/QuiltLoader.java
+++ b/src/main/java/org/quiltmc/loader/api/QuiltLoader.java
@@ -23,10 +23,8 @@ import java.util.Optional;
 
 import org.jetbrains.annotations.Nullable;
 import org.quiltmc.loader.api.entrypoint.EntrypointContainer;
+import org.quiltmc.loader.api.entrypoint.EntrypointException;
 import org.quiltmc.loader.impl.QuiltLoaderImpl;
-
-import net.fabricmc.loader.api.EntrypointException;
-import net.fabricmc.loader.api.LanguageAdapter;
 
 import net.fabricmc.api.EnvType;
 
@@ -56,9 +54,10 @@ public interface QuiltLoader {
 	 * @param type the type of entrypoints
 	 * @param <T>  the type of entrypoints
 	 * @return the obtained entrypoints
+	 * @throws EntrypointException if a problem arises during entrypoint creation
 	 * @see #getEntrypointContainers(String, Class)
 	 */
-	<T> List<T> getEntrypoints(String key, Class<T> type);
+	<T> List<T> getEntrypoints(String key, Class<T> type) throws EntrypointException;
 
 	/**
 	 * Returns all entrypoints declared under a {@code key}, assuming they are of a specific type.
@@ -99,7 +98,8 @@ public interface QuiltLoader {
 	 * @throws EntrypointException if a problem arises during entrypoint creation
 	 * @see LanguageAdapter
 	 */
-	<T> List<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type);
+	<T> List<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type)
+		throws EntrypointException;
 
 	/**
 	 * Get the current mapping resolver.

--- a/src/main/java/org/quiltmc/loader/api/QuiltLoader.java
+++ b/src/main/java/org/quiltmc/loader/api/QuiltLoader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.loader.api;
 
 import java.nio.file.Path;

--- a/src/main/java/org/quiltmc/loader/api/QuiltLoader.java
+++ b/src/main/java/org/quiltmc/loader/api/QuiltLoader.java
@@ -30,22 +30,9 @@ import net.fabricmc.api.EnvType;
 
 /**
  * The public-facing FabricLoader instance.
- *
- * <p>To obtain a working instance, call {@link #getInstance()}.</p>
- *
- * @since 0.4.0
  */
-public interface QuiltLoader {
-	/**
-	 * Returns the public-facing Quilt Loader instance.
-	 */
-	static QuiltLoader getInstance() {
-		if (QuiltLoaderImpl.INSTANCE == null) {
-			throw new RuntimeException("Accessed QuiltLoader too early!");
-		}
-
-		return QuiltLoaderImpl.INSTANCE;
-	}
+public final class QuiltLoader {
+	private QuiltLoader() {}
 
 	/**
 	 * Returns all entrypoints declared under a {@code key}, assuming they are of a specific type.
@@ -57,7 +44,9 @@ public interface QuiltLoader {
 	 * @throws EntrypointException if a problem arises during entrypoint creation
 	 * @see #getEntrypointContainers(String, Class)
 	 */
-	<T> List<T> getEntrypoints(String key, Class<T> type) throws EntrypointException;
+	public static <T> List<T> getEntrypoints(String key, Class<T> type) throws EntrypointException {
+		return impl().getEntrypoints(key, type);
+	}
 
 	/**
 	 * Returns all entrypoints declared under a {@code key}, assuming they are of a specific type.
@@ -98,8 +87,9 @@ public interface QuiltLoader {
 	 * @throws EntrypointException if a problem arises during entrypoint creation
 	 * @see LanguageAdapter
 	 */
-	<T> List<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type)
-		throws EntrypointException;
+	public static <T> List<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type) throws EntrypointException {
+		return impl().getEntrypointContainers(key, type);
+	}
 
 	/**
 	 * Get the current mapping resolver.
@@ -110,7 +100,9 @@ public interface QuiltLoader {
 	 * @return the current mapping resolver instance
 	 * @since 0.4.1
 	 */
-	MappingResolver getMappingResolver();
+	public static MappingResolver getMappingResolver() {
+		return impl().getMappingResolver();
+	}
 
 	/**
 	 * Gets the container for a given mod.
@@ -118,14 +110,18 @@ public interface QuiltLoader {
 	 * @param id the ID of the mod
 	 * @return the mod container, if present
 	 */
-	Optional<ModContainer> getModContainer(String id);
+	public static Optional<ModContainer> getModContainer(String id) {
+		return impl().getModContainer(id);
+	}
 
 	/**
 	 * Gets all mod containers.
 	 *
 	 * @return a collection of all loaded mod containers
 	 */
-	Collection<ModContainer> getAllMods();
+	public static Collection<ModContainer> getAllMods() {
+		return impl().getAllMods();
+	}
 
 	/**
 	 * Checks if a mod with a given ID is loaded.
@@ -133,7 +129,9 @@ public interface QuiltLoader {
 	 * @param id the ID of the mod, as defined in {@code fabric.mod.json}
 	 * @return whether or not the mod is present in this Fabric Loader instance
 	 */
-	boolean isModLoaded(String id);
+	public static boolean isModLoaded(String id) {
+		return impl().isModLoaded(id);
+	}
 
 	/**
 	 * Checks if Fabric Loader is currently running in a "development"
@@ -145,14 +143,9 @@ public interface QuiltLoader {
 	 * @return whether or not Loader is currently in a "development"
 	 * environment
 	 */
-	boolean isDevelopmentEnvironment();
-
-	/**
-	 * Get the current environment type.
-	 *
-	 * @return the current environment type
-	 */
-	EnvType getEnvironmentType();
+	public static boolean isDevelopmentEnvironment() {
+		return impl().isDevelopmentEnvironment();
+	}
 
 	/**
 	 * Get the current game instance. Can represent a game client or
@@ -166,26 +159,42 @@ public interface QuiltLoader {
 	 */
 	@Nullable
 	@Deprecated
-	Object getGameInstance();
+	public static Object getGameInstance() {
+		return impl().getGameInstance();
+	}
 
 	/**
 	 * Get the current game working directory.
 	 *
 	 * @return the working directory
 	 */
-	Path getGameDir();
+	public static Path getGameDir() {
+		return impl().getGameDir();
+	}
 
 	/**
 	 * Get the current directory for game configuration files.
 	 *
 	 * @return the configuration directory
 	 */
-	Path getConfigDir();
+	public static Path getConfigDir() {
+		return impl().getConfigDir();
+	}
 
 	/**
 	 * Gets the command line arguments used to launch the game. If this is printed for debugging, make sure {@code sanitize} is {@code true}.
 	 * @param sanitize Whether to remove sensitive information
 	 * @return the launch arguments
 	 */
-	String[] getLaunchArguments(boolean sanitize);
+	public static String[] getLaunchArguments(boolean sanitize) {
+		return impl().getLaunchArguments(sanitize);
+	}
+
+	private static QuiltLoaderImpl impl() {
+		if (QuiltLoaderImpl.INSTANCE == null) {
+			throw new RuntimeException("Accessed QuiltLoader too early!");
+ 		}
+
+		return QuiltLoaderImpl.INSTANCE;
+	}
 }

--- a/src/main/java/org/quiltmc/loader/api/entrypoint/EntrypointContainer.java
+++ b/src/main/java/org/quiltmc/loader/api/entrypoint/EntrypointContainer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.loader.api.entrypoint;
 
 import org.quiltmc.loader.api.ModContainer;

--- a/src/main/java/org/quiltmc/loader/api/entrypoint/EntrypointContainer.java
+++ b/src/main/java/org/quiltmc/loader/api/entrypoint/EntrypointContainer.java
@@ -1,0 +1,21 @@
+package org.quiltmc.loader.api.entrypoint;
+
+import org.quiltmc.loader.api.ModContainer;
+
+/**
+ * A container holding both an entrypoint instance and the {@link ModContainer} which has provided the entrypoint.
+ *
+ * @param <T> The type of the entrypoint
+ * @see org.quiltmc.loader.api.QuiltLoader#getEntrypointContainers(String, Class) 
+ */
+public interface EntrypointContainer<T> {
+	/**
+	 * Returns the entrypoint instance. It will be constructed the first time you call this method.
+	 */
+	T getEntrypoint();
+
+	/**
+	 * Returns the mod that provided this entrypoint.
+	 */
+	ModContainer getProvider();
+}

--- a/src/main/java/org/quiltmc/loader/api/entrypoint/EntrypointException.java
+++ b/src/main/java/org/quiltmc/loader/api/entrypoint/EntrypointException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.loader.api.entrypoint;
 
 import org.quiltmc.loader.api.QuiltLoader;

--- a/src/main/java/org/quiltmc/loader/api/entrypoint/EntrypointException.java
+++ b/src/main/java/org/quiltmc/loader/api/entrypoint/EntrypointException.java
@@ -1,0 +1,33 @@
+package org.quiltmc.loader.api.entrypoint;
+
+import org.quiltmc.loader.api.QuiltLoader;
+
+/**
+ * Represents an exception that arises when obtaining entrypoints.
+ * 
+ * @see QuiltLoader#getEntrypointContainers(String, Class) 
+ */
+@SuppressWarnings("serial")
+public abstract class EntrypointException extends RuntimeException {
+
+	public EntrypointException() {}
+
+	public EntrypointException(String message) {
+		super(message);
+	}
+
+	public EntrypointException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public EntrypointException(Throwable cause) {
+		super(cause);
+	}
+
+	/**
+	 * Returns the key of entrypoint in which the exception arose.
+	 *
+	 * @return the key
+	 */
+	public abstract String getKey();
+}

--- a/src/main/java/org/quiltmc/loader/api/entrypoint/GameEntrypoint.java
+++ b/src/main/java/org/quiltmc/loader/api/entrypoint/GameEntrypoint.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.loader.api.entrypoint;
 
 /** Marker interface for quilt entrypoints. Generally only entrypoint interfaces should extend this - and then only for

--- a/src/main/java/org/quiltmc/loader/api/entrypoint/GameEntrypoint.java
+++ b/src/main/java/org/quiltmc/loader/api/entrypoint/GameEntrypoint.java
@@ -1,0 +1,7 @@
+package org.quiltmc.loader.api.entrypoint;
+
+/** Marker interface for quilt entrypoints. Generally only entrypoint interfaces should extend this - and then only for
+ * entrypoints that might want to migrate to a different sort later on! */
+public interface GameEntrypoint {
+
+}

--- a/src/main/java/org/quiltmc/loader/api/entrypoint/GameEntrypoint.java
+++ b/src/main/java/org/quiltmc/loader/api/entrypoint/GameEntrypoint.java
@@ -16,8 +16,11 @@
 
 package org.quiltmc.loader.api.entrypoint;
 
+import org.jetbrains.annotations.ApiStatus;
+
 /** Marker interface for quilt entrypoints. Generally only entrypoint interfaces should extend this - and then only for
- * entrypoints that might want to migrate to a different sort later on! */
+ * entrypoints that might want to migrate to a different sort later on!*/
+@ApiStatus.NonExtendable
 public interface GameEntrypoint {
 
 }

--- a/src/main/java/org/quiltmc/loader/api/entrypoint/PreLaunchEntrypoint.java
+++ b/src/main/java/org/quiltmc/loader/api/entrypoint/PreLaunchEntrypoint.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.loader.api.entrypoint;
 
 import org.quiltmc.loader.api.ModContainer;

--- a/src/main/java/org/quiltmc/loader/api/entrypoint/PreLaunchEntrypoint.java
+++ b/src/main/java/org/quiltmc/loader/api/entrypoint/PreLaunchEntrypoint.java
@@ -1,0 +1,21 @@
+package org.quiltmc.loader.api.entrypoint;
+
+import org.quiltmc.loader.api.ModContainer;
+
+/**
+ * Entrypoint getting invoked just before launching the game.
+ *
+ * <p><b>Avoid interfering with the game from this!</b> Accessing anything needs careful consideration to avoid
+ * interfering with its own initialization or otherwise harming its state. It is recommended to implement this interface
+ * on its own class to avoid running static initializers too early, e.g. because they were referenced in field or method
+ * signatures in the same class.
+ *
+ * <p>The entrypoint is exposed with {@code preLaunch} key in the mod json and runs for any environment. It usually
+ * executes several seconds before the {@code main}/{@code client}/{@code server} entrypoints.
+ * 
+ * @see net.fabricmc.loader.api.FabricLoader#getEntrypointContainers(String, Class) 
+ */
+@FunctionalInterface
+public interface PreLaunchEntrypoint extends GameEntrypoint {
+	void onPreLaunch(ModContainer mod);
+}

--- a/src/main/java/org/quiltmc/loader/api/minecraft/ClientModInitializer.java
+++ b/src/main/java/org/quiltmc/loader/api/minecraft/ClientModInitializer.java
@@ -1,0 +1,25 @@
+package org.quiltmc.loader.api.minecraft;
+
+import org.quiltmc.loader.api.ModContainer;
+
+import net.fabricmc.api.EnvType;
+
+/**
+ * A mod initializer ran only on {@link EnvType#CLIENT}.
+ *
+ * <p>This entrypoint is suitable for setting up client-specific logic, such as rendering
+ * or integrated server tweaks.</p>
+ *
+ * <p>In {@code fabric.mod.json}, the entrypoint is defined with {@code client} key.</p>
+ *
+ * @see ModInitializer
+ * @see DedicatedServerModInitializer
+ * @see org.quiltmc.loader.api.QuiltLoader#getEntrypointContainers(String, Class)
+ */
+@FunctionalInterface
+public interface ClientModInitializer {
+	/**
+	 * Runs the mod initializer on the client environment.
+	 */
+	void onInitializeClient(ModContainer mod);
+}

--- a/src/main/java/org/quiltmc/loader/api/minecraft/ClientModInitializer.java
+++ b/src/main/java/org/quiltmc/loader/api/minecraft/ClientModInitializer.java
@@ -17,6 +17,7 @@
 package org.quiltmc.loader.api.minecraft;
 
 import org.quiltmc.loader.api.ModContainer;
+import org.quiltmc.loader.api.entrypoint.GameEntrypoint;
 
 import net.fabricmc.api.EnvType;
 
@@ -33,7 +34,7 @@ import net.fabricmc.api.EnvType;
  * @see org.quiltmc.loader.api.QuiltLoader#getEntrypointContainers(String, Class)
  */
 @FunctionalInterface
-public interface ClientModInitializer {
+public interface ClientModInitializer extends GameEntrypoint {
 	/**
 	 * Runs the mod initializer on the client environment.
 	 */

--- a/src/main/java/org/quiltmc/loader/api/minecraft/ClientModInitializer.java
+++ b/src/main/java/org/quiltmc/loader/api/minecraft/ClientModInitializer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.loader.api.minecraft;
 
 import org.quiltmc.loader.api.ModContainer;

--- a/src/main/java/org/quiltmc/loader/api/minecraft/DedicatedServerModInitializer.java
+++ b/src/main/java/org/quiltmc/loader/api/minecraft/DedicatedServerModInitializer.java
@@ -17,6 +17,7 @@
 package org.quiltmc.loader.api.minecraft;
 
 import org.quiltmc.loader.api.ModContainer;
+import org.quiltmc.loader.api.entrypoint.GameEntrypoint;
 
 /**
  * A mod initializer ran only on {@link EnvType#SERVER}.
@@ -28,7 +29,7 @@ import org.quiltmc.loader.api.ModContainer;
  * @see org.quiltmc.loader.api.QuiltLoader#getEntrypointContainers(String, Class)
  */
 @FunctionalInterface
-public interface DedicatedServerModInitializer {
+public interface DedicatedServerModInitializer extends GameEntrypoint {
 	/**
 	 * Runs the mod initializer on the server environment.
 	 */

--- a/src/main/java/org/quiltmc/loader/api/minecraft/DedicatedServerModInitializer.java
+++ b/src/main/java/org/quiltmc/loader/api/minecraft/DedicatedServerModInitializer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.loader.api.minecraft;
 
 import org.quiltmc.loader.api.ModContainer;

--- a/src/main/java/org/quiltmc/loader/api/minecraft/DedicatedServerModInitializer.java
+++ b/src/main/java/org/quiltmc/loader/api/minecraft/DedicatedServerModInitializer.java
@@ -1,0 +1,20 @@
+package org.quiltmc.loader.api.minecraft;
+
+import org.quiltmc.loader.api.ModContainer;
+
+/**
+ * A mod initializer ran only on {@link EnvType#SERVER}.
+ *
+ * <p>In {@code fabric.mod.json}, the entrypoint is defined with {@code server} key.</p>
+ *
+ * @see ModInitializer
+ * @see ClientModInitializer
+ * @see org.quiltmc.loader.api.QuiltLoader#getEntrypointContainers(String, Class)
+ */
+@FunctionalInterface
+public interface DedicatedServerModInitializer {
+	/**
+	 * Runs the mod initializer on the server environment.
+	 */
+	void onInitializeServer(ModContainer mod);
+}

--- a/src/main/java/org/quiltmc/loader/api/minecraft/MinecraftQuiltLoader.java
+++ b/src/main/java/org/quiltmc/loader/api/minecraft/MinecraftQuiltLoader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.loader.api.minecraft;
 
 import org.quiltmc.loader.impl.QuiltLoaderImpl;

--- a/src/main/java/org/quiltmc/loader/api/minecraft/MinecraftQuiltLoader.java
+++ b/src/main/java/org/quiltmc/loader/api/minecraft/MinecraftQuiltLoader.java
@@ -1,0 +1,24 @@
+package org.quiltmc.loader.api.minecraft;
+
+import org.quiltmc.loader.impl.QuiltLoaderImpl;
+
+import net.fabricmc.api.EnvType;
+
+/** Public access for some minecraft-specific functionality in quilt loader. */
+public final class MinecraftQuiltLoader {
+	private MinecraftQuiltLoader() {}
+
+	/**
+	 * Get the current environment type.
+	 *
+	 * @return the current environment type
+	 */
+	public static EnvType getEnvironmentType() {
+		// TODO: Get this from a plugin instead!
+		QuiltLoaderImpl impl = QuiltLoaderImpl.INSTANCE;
+		if (impl == null) {
+			throw new IllegalStateException("Accessed QuiltLoader too early!");
+		}
+		return impl.getEnvironmentType();
+	}
+}

--- a/src/main/java/org/quiltmc/loader/api/minecraft/ModInitializer.java
+++ b/src/main/java/org/quiltmc/loader/api/minecraft/ModInitializer.java
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-package org.quiltmc.loader.api;
+package org.quiltmc.loader.api.minecraft;
+
+import org.quiltmc.loader.api.ModContainer;
+import org.quiltmc.loader.api.QuiltLoader;
 
 /**
  * A mod initializer.

--- a/src/main/java/org/quiltmc/loader/impl/ModContainer.java
+++ b/src/main/java/org/quiltmc/loader/impl/ModContainer.java
@@ -16,7 +16,7 @@
 
 package org.quiltmc.loader.impl;
 
-import net.fabricmc.loader.api.metadata.ModMetadata;
+import org.quiltmc.loader.api.ModMetadata;
 import org.quiltmc.loader.impl.metadata.LoaderModMetadata;
 import org.quiltmc.loader.impl.metadata.qmj.InternalModMetadata;
 import org.quiltmc.loader.impl.util.FileSystemUtil;
@@ -28,7 +28,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-public class ModContainer implements net.fabricmc.loader.api.ModContainer {
+public class ModContainer implements org.quiltmc.loader.api.ModContainer {
 	private final InternalModMetadata meta;
 	private final LoaderModMetadata fabricMeta;
 	private final URL originUrl;
@@ -41,12 +41,12 @@ public class ModContainer implements net.fabricmc.loader.api.ModContainer {
 	}
 
 	@Override
-	public ModMetadata getMetadata() {
-		return fabricMeta;
+	public ModMetadata metadata() {
+		return meta;
 	}
 
 	@Override
-	public Path getRootPath() {
+	public Path rootPath() {
 		Path ret = root;
 
 		if (ret == null) {

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -68,7 +68,7 @@ import org.objectweb.asm.Opcodes;
  * The main class for mod loading operations.
  */
 @ApiStatus.Internal
-public class QuiltLoaderImpl implements QuiltLoader {
+public class QuiltLoaderImpl {
 	public static final QuiltLoaderImpl INSTANCE = new QuiltLoaderImpl();
 
 	public static final int ASM_VERSION = Opcodes.ASM9;
@@ -77,11 +77,6 @@ public class QuiltLoaderImpl implements QuiltLoader {
 
 	public static final String DEFAULT_MODS_DIR = "mods";
 	public static final String DEFAULT_CONFIG_DIR = "config";
-
-	/** @deprecated This will be moved to a plugin when they are implemented. Mods should use
-	 *             {@link FabricLoader#getInstance()} instead. */
-	@Deprecated
-	public final Quilt2FabricLoader quilt2Fabric = new Quilt2FabricLoader(this);
 
 	protected final Map<String, ModContainer> modMap = new HashMap<>();
 	protected List<ModContainer> mods = new ArrayList<>();
@@ -139,12 +134,10 @@ public class QuiltLoaderImpl implements QuiltLoader {
 		this.modsDir = gameDir.resolve((modsDir == null || modsDir.isEmpty()) ? DEFAULT_MODS_DIR : modsDir);
 	}
 
-	@Override
 	public Object getGameInstance() {
 		return gameInstance;
 	}
 
-	@Override
 	public EnvType getEnvironmentType() {
 		return QuiltLauncherBase.getLauncher().getEnvironmentType();
 	}
@@ -152,7 +145,6 @@ public class QuiltLoaderImpl implements QuiltLoader {
 	/**
 	 * @return The game instance's root directory.
 	 */
-	@Override
 	public Path getGameDir() {
 		return gameDir;
 	}
@@ -160,7 +152,6 @@ public class QuiltLoaderImpl implements QuiltLoader {
 	/**
 	 * @return The game instance's configuration directory.
 	 */
-	@Override
 	public Path getConfigDir() {
 		if (configDir == null) {
 			// May be null during tests
@@ -272,17 +263,14 @@ public class QuiltLoaderImpl implements QuiltLoader {
 		return entrypointStorage.hasEntrypoints(key);
 	}
 
-	@Override
 	public <T> List<T> getEntrypoints(String key, Class<T> type) {
 		return entrypointStorage.getEntrypoints(key, type);
 	}
 
-	@Override
 	public <T> List<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type) {
 		return entrypointStorage.getEntrypointContainers(key, type);
 	}
 
-	@Override
 	public MappingResolver getMappingResolver() {
 		if (mappingResolver == null) {
 			mappingResolver = new QuiltMappingResolver(
@@ -294,22 +282,18 @@ public class QuiltLoaderImpl implements QuiltLoader {
 		return mappingResolver;
 	}
 
-	@Override
 	public Optional<org.quiltmc.loader.api.ModContainer> getModContainer(String id) {
 		return Optional.ofNullable(modMap.get(id));
 	}
 
-	@Override
 	public Collection<org.quiltmc.loader.api.ModContainer> getAllMods() {
 		return Collections.unmodifiableList(mods);
 	}
 
-	@Override
 	public boolean isModLoaded(String id) {
 		return modMap.containsKey(id);
 	}
 
-	@Override
 	public boolean isDevelopmentEnvironment() {
 		QuiltLauncher launcher = QuiltLauncherBase.getLauncher();
 		if (launcher == null) {
@@ -527,7 +511,6 @@ public class QuiltLoaderImpl implements QuiltLoader {
 		this.gameInstance = gameInstance;
 	}
 
-	@Override
 	public String[] getLaunchArguments(boolean sanitize) {
 		return getGameProvider().getLaunchArguments(sanitize);
 	}

--- a/src/main/java/org/quiltmc/loader/impl/QuiltMappingResolver.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltMappingResolver.java
@@ -24,7 +24,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import net.fabricmc.loader.api.MappingResolver;
+import org.quiltmc.loader.api.MappingResolver;
+
 import net.fabricmc.mapping.tree.ClassDef;
 import net.fabricmc.mapping.tree.Descriptored;
 import net.fabricmc.mapping.tree.TinyTree;

--- a/src/main/java/org/quiltmc/loader/impl/entrypoint/EntrypointContainerImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/entrypoint/EntrypointContainerImpl.java
@@ -16,10 +16,10 @@
 
 package org.quiltmc.loader.impl.entrypoint;
 
-import net.fabricmc.loader.api.ModContainer;
-import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
-
 import java.util.function.Supplier;
+
+import org.quiltmc.loader.api.ModContainer;
+import org.quiltmc.loader.api.entrypoint.EntrypointContainer;
 
 public class EntrypointContainerImpl<T> implements EntrypointContainer<T> {
 	private final ModContainer container;

--- a/src/main/java/org/quiltmc/loader/impl/entrypoint/QuiltEntrypointException.java
+++ b/src/main/java/org/quiltmc/loader/impl/entrypoint/QuiltEntrypointException.java
@@ -1,0 +1,33 @@
+package org.quiltmc.loader.impl.entrypoint;
+
+import org.quiltmc.loader.api.entrypoint.EntrypointException;
+
+public class QuiltEntrypointException extends EntrypointException {
+
+	private final String key;
+
+	public QuiltEntrypointException(String key, Throwable cause) {
+		super("Exception while loading entries for entrypoint '" + key + "'!", cause);
+		this.key = key;
+	}
+
+	public QuiltEntrypointException(String key, String causingMod, Throwable cause) {
+		super("Exception while loading entries for entrypoint '" + key + "' provided by '" + causingMod + "'", cause);
+		this.key = key;
+	}
+
+	public QuiltEntrypointException(String s) {
+		super(s);
+		this.key = "";
+	}
+
+	public QuiltEntrypointException(Throwable t) {
+		super(t);
+		this.key = "";
+	}
+
+	@Override
+	public String getKey() {
+		return key;
+	}
+}

--- a/src/main/java/org/quiltmc/loader/impl/entrypoint/QuiltEntrypointException.java
+++ b/src/main/java/org/quiltmc/loader/impl/entrypoint/QuiltEntrypointException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.loader.impl.entrypoint;
 
 import org.quiltmc.loader.api.entrypoint.EntrypointException;

--- a/src/main/java/org/quiltmc/loader/impl/entrypoint/minecraft/hooks/EntrypointClient.java
+++ b/src/main/java/org/quiltmc/loader/impl/entrypoint/minecraft/hooks/EntrypointClient.java
@@ -16,8 +16,8 @@
 
 package org.quiltmc.loader.impl.entrypoint.minecraft.hooks;
 
-import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.api.ModInitializer;
+import org.quiltmc.loader.api.ModInitializer;
+import org.quiltmc.loader.api.minecraft.ClientModInitializer;
 import org.quiltmc.loader.impl.QuiltLoaderImpl;
 
 import java.io.File;

--- a/src/main/java/org/quiltmc/loader/impl/entrypoint/minecraft/hooks/EntrypointClient.java
+++ b/src/main/java/org/quiltmc/loader/impl/entrypoint/minecraft/hooks/EntrypointClient.java
@@ -16,8 +16,8 @@
 
 package org.quiltmc.loader.impl.entrypoint.minecraft.hooks;
 
-import org.quiltmc.loader.api.ModInitializer;
 import org.quiltmc.loader.api.minecraft.ClientModInitializer;
+import org.quiltmc.loader.api.minecraft.ModInitializer;
 import org.quiltmc.loader.impl.QuiltLoaderImpl;
 
 import java.io.File;

--- a/src/main/java/org/quiltmc/loader/impl/entrypoint/minecraft/hooks/EntrypointServer.java
+++ b/src/main/java/org/quiltmc/loader/impl/entrypoint/minecraft/hooks/EntrypointServer.java
@@ -16,8 +16,8 @@
 
 package org.quiltmc.loader.impl.entrypoint.minecraft.hooks;
 
-import org.quiltmc.loader.api.ModInitializer;
 import org.quiltmc.loader.api.minecraft.DedicatedServerModInitializer;
+import org.quiltmc.loader.api.minecraft.ModInitializer;
 import org.quiltmc.loader.impl.QuiltLoaderImpl;
 
 import java.io.File;

--- a/src/main/java/org/quiltmc/loader/impl/entrypoint/minecraft/hooks/EntrypointServer.java
+++ b/src/main/java/org/quiltmc/loader/impl/entrypoint/minecraft/hooks/EntrypointServer.java
@@ -16,8 +16,8 @@
 
 package org.quiltmc.loader.impl.entrypoint.minecraft.hooks;
 
-import net.fabricmc.api.DedicatedServerModInitializer;
-import net.fabricmc.api.ModInitializer;
+import org.quiltmc.loader.api.ModInitializer;
+import org.quiltmc.loader.api.minecraft.DedicatedServerModInitializer;
 import org.quiltmc.loader.impl.QuiltLoaderImpl;
 
 import java.io.File;

--- a/src/main/java/org/quiltmc/loader/impl/entrypoint/minecraft/hooks/EntrypointUtils.java
+++ b/src/main/java/org/quiltmc/loader/impl/entrypoint/minecraft/hooks/EntrypointUtils.java
@@ -16,14 +16,24 @@
 
 package org.quiltmc.loader.impl.entrypoint.minecraft.hooks;
 
+import org.quiltmc.loader.api.ModContainer;
+import org.quiltmc.loader.api.entrypoint.EntrypointContainer;
 import org.quiltmc.loader.impl.QuiltLoaderImpl;
-import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
 
 import java.util.Collection;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public final class EntrypointUtils {
 	public static <T> void invoke(String name, Class<T> type, Consumer<? super T> invoker) {
+		invokeContainer(name, type, container -> invoker.accept(container.getEntrypoint()));
+	}
+
+	public static <T> void invoke(String name, Class<T> type, BiConsumer<T, ModContainer> invoker) {
+		invokeContainer(name, type, container -> invoker.accept(container.getEntrypoint(), container.getProvider()));
+	}
+
+	public static <T> void invokeContainer(String name, Class<T> type, Consumer<EntrypointContainer<T>> invoker) {
 		QuiltLoaderImpl loader = QuiltLoaderImpl.INSTANCE;
 
 		if (!loader.hasEntrypoints(name)) {
@@ -33,7 +43,7 @@ public final class EntrypointUtils {
 		}
 	}
 
-	private static <T> void invoke0(String name, Class<T> type, Consumer<? super T> invoker) {
+	private static <T> void invoke0(String name, Class<T> type, Consumer<EntrypointContainer<T>> invoker) {
 		QuiltLoaderImpl loader = QuiltLoaderImpl.INSTANCE;
 		RuntimeException exception = null;
 		Collection<EntrypointContainer<T>> entrypoints = loader.getEntrypointContainers(name, type);
@@ -42,10 +52,10 @@ public final class EntrypointUtils {
 
 		for (EntrypointContainer<T> container : entrypoints) {
 			try {
-				invoker.accept(container.getEntrypoint());
+				invoker.accept(container);
 			} catch (Throwable t) {
 				if (exception == null) {
-					exception = new RuntimeException("Could not execute entrypoint stage '" + name + "' due to errors, provided by '" + container.getProvider().getMetadata().getId() + "'!", t);
+					exception = new RuntimeException("Could not execute entrypoint stage '" + name + "' due to errors, provided by '" + container.getProvider().metadata().id() + "'!", t);
 				} else {
 					exception.addSuppressed(t);
 				}

--- a/src/main/java/org/quiltmc/loader/impl/launch/QuiltTweaker.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/QuiltTweaker.java
@@ -17,8 +17,9 @@
 package org.quiltmc.loader.impl.launch;
 
 import net.fabricmc.api.EnvType;
+
+import org.quiltmc.loader.api.entrypoint.PreLaunchEntrypoint;
 import org.quiltmc.loader.impl.QuiltLoaderImpl;
-import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 import org.quiltmc.loader.impl.entrypoint.minecraft.hooks.EntrypointUtils;
 import org.quiltmc.loader.impl.game.GameProvider;
 import org.quiltmc.loader.impl.game.MinecraftGameProvider;

--- a/src/main/java/org/quiltmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/knot/Knot.java
@@ -17,8 +17,9 @@
 package org.quiltmc.loader.impl.launch.knot;
 
 import net.fabricmc.api.EnvType;
+
+import org.quiltmc.loader.api.entrypoint.PreLaunchEntrypoint;
 import org.quiltmc.loader.impl.QuiltLoaderImpl;
-import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 import org.quiltmc.loader.impl.entrypoint.minecraft.hooks.EntrypointUtils;
 import org.quiltmc.loader.impl.game.GameProvider;
 import org.quiltmc.loader.impl.game.GameProviders;

--- a/src/main/java/org/quiltmc/loader/impl/util/DefaultLanguageAdapter.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/DefaultLanguageAdapter.java
@@ -16,9 +16,9 @@
 
 package org.quiltmc.loader.impl.util;
 
-import net.fabricmc.loader.api.LanguageAdapter;
-import net.fabricmc.loader.api.LanguageAdapterException;
-import net.fabricmc.loader.api.ModContainer;
+import org.quiltmc.loader.api.LanguageAdapter;
+import org.quiltmc.loader.api.LanguageAdapterException;
+import org.quiltmc.loader.api.ModContainer;
 import org.quiltmc.loader.impl.launch.common.QuiltLauncherBase;
 
 import java.lang.invoke.MethodHandle;


### PR DESCRIPTION
Changes:

* Everything in the `net.fabricmc.api` and `net.fabricmc.loader.api` packages has been deprecated, except for `@Environment`, `@EnvironmentInterface`, `@EnvironmentInterfaces`, and `EnvType`. All usages of these classes and interfaces should get correctly redirected or used by quilt's classes. (in particular fabric mods that implement fabric's entrypoints will continue to be called by quilt's entrypoint invocations).
* `QuiltLoader` (replacing `FabricLoader`) is a static class, with only static functions.
* `getEnvironmentType()` has been moved to a minecraft specific class `MinecraftQuiltLoader`
* Entrypoints:
    * All quilt entrypoints extend a new interface `GameEntrypoint`, which is empty.
    * All entrypoint methods include the `ModContainer` as an argument (#26)
    * `ModInitializer`, `ClientModInitializer` and `DedicatedServerModInitializer` have been moved to a minecraft-specific api package (`org.quiltmc.loader.api.minecraft`)