### PR TITLE
Refactor the ModDependency model.

### DIFF
--- a/src/main/java/org/quiltmc/loader/api/ModMetadata.java
+++ b/src/main/java/org/quiltmc/loader/api/ModMetadata.java
@@ -90,14 +90,9 @@ public interface ModMetadata {
 	Map<String, String> contactInfo();
 
 	/**
-	 * @return all mod dependencies this mod depends on
+	 * @return all mod dependencies this mod has
 	 */
-	Collection<ModDependency> depends();
-
-	/**
-	 * @return all mod dependencies this mod conflicts with
-	 */
-	Collection<ModDependency> breaks();
+	Collection<ModDependency> relations();
 
 	/**
 	 * Gets the path to an icon.

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/V1ModMetadataImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/V1ModMetadataImpl.java
@@ -40,8 +40,7 @@ final class V1ModMetadataImpl implements InternalModMetadata {
 	private final Collection<ModLicense> licenses;
 	private final Collection<ModContributor> contributors;
 	private final Map<String, String> contactInformation;
-	private final Collection<ModDependency> depends;
-	private final Collection<ModDependency> breaks;
+	private final Collection<ModDependency> relations;
 	private final Icons icons;
 	/* Internal fields */
 	private final ModLoadType loadType;
@@ -66,8 +65,7 @@ final class V1ModMetadataImpl implements InternalModMetadata {
 			Collection<ModLicense> licenses,
 			Collection<ModContributor> contributors,
 			Map<String, String> contactInformation,
-			Collection<ModDependency> depends,
-			Collection<ModDependency> breaks,
+			Collection<ModDependency> relations,
 			@Nullable Icons icons,
 			/* Internal fields */
 			ModLoadType loadType,
@@ -105,8 +103,7 @@ final class V1ModMetadataImpl implements InternalModMetadata {
 		this.licenses = Collections.unmodifiableCollection(licenses);
 		this.contributors = Collections.unmodifiableCollection(contributors);
 		this.contactInformation = Collections.unmodifiableMap(contactInformation);
-		this.depends = Collections.unmodifiableCollection(depends);
-		this.breaks = Collections.unmodifiableCollection(breaks);
+		this.relations = Collections.unmodifiableCollection(relations);
 
 		if (icons != null) {
 			this.icons = icons;
@@ -176,13 +173,8 @@ final class V1ModMetadataImpl implements InternalModMetadata {
 	}
 
 	@Override
-	public Collection<ModDependency> depends() {
-		return this.depends;
-	}
-
-	@Override
-	public Collection<ModDependency> breaks() {
-		return this.breaks;
+	public Collection<ModDependency> relations() {
+		return relations;
 	}
 
 	@Nullable

--- a/src/main/java/org/quiltmc/loader/impl/solver/ModSolver.java
+++ b/src/main/java/org/quiltmc/loader/impl/solver/ModSolver.java
@@ -172,22 +172,25 @@ public final class ModSolver {
 					sat.addOption(new ProvidedModOption(cOption, provided));
 				}
 
-				for (org.quiltmc.loader.api.ModDependency dep : m.getMetadata().depends()) {
 
+				for (org.quiltmc.loader.api.ModDependency dep : m.getMetadata().relations()) {
 					if (dep.shouldIgnore()) {
 						continue;
 					}
 
-					sat.addRule(createModDepLink(logger, sat, cOption, dep));
-				}
 
-				for (org.quiltmc.loader.api.ModDependency dep : m.getMetadata().breaks()) {
-
-					if (dep.shouldIgnore()) {
-						continue;
+					switch (dep.kind()) {
+						case DEPENDS:
+							sat.addRule(createModDepLink(logger, sat, cOption, dep));
+							continue;
+						case BREAKS:
+							sat.addRule(createModBreaks(logger, sat, cOption, dep));
+							continue;
+						case UNLESS:
+							throw new IllegalArgumentException("Illegal dependency kind " + dep.kind());
+						default:
+							throw new IllegalArgumentException("Unknown dependency kind " + dep.kind());
 					}
-
-					sat.addRule(createModBreaks(logger, sat, cOption, dep));
 				}
 			}
 		}
@@ -376,21 +379,21 @@ public final class ModSolver {
 
 			return new QuiltRuleDepAny(logger, ctx, option, any);
 		} else {
-			org.quiltmc.loader.api.ModDependency.Only only = (org.quiltmc.loader.api.ModDependency.Only) dep;
+			org.quiltmc.loader.api.ModDependency.Entry entry = (org.quiltmc.loader.api.ModDependency.Entry) dep;
 
-			return new QuiltRuleDepOnly(logger, ctx, option, only);
+			return new QuiltRuleDepOnly(logger, ctx, option, entry);
 		}
 	}
 
 	public static QuiltRuleBreak createModBreaks(Logger logger, RuleContext ctx, LoadOption option, org.quiltmc.loader.api.ModDependency dep) {
-		if (dep instanceof org.quiltmc.loader.api.ModDependency.All) {
-			org.quiltmc.loader.api.ModDependency.All any = (org.quiltmc.loader.api.ModDependency.All) dep;
+		if (dep instanceof org.quiltmc.loader.api.ModDependency.Any) {
+			org.quiltmc.loader.api.ModDependency.Any any = (org.quiltmc.loader.api.ModDependency.Any) dep;
 
 			return new QuiltRuleBreakAll(logger, ctx, option, any);
 		} else {
-			org.quiltmc.loader.api.ModDependency.Only only = (org.quiltmc.loader.api.ModDependency.Only) dep;
+			org.quiltmc.loader.api.ModDependency.Entry entry = (org.quiltmc.loader.api.ModDependency.Entry) dep;
 
-			return new QuiltRuleBreakOnly(logger, ctx, option, only);
+			return new QuiltRuleBreakOnly(logger, ctx, option, entry);
 		}
 	}
 

--- a/src/main/java/org/quiltmc/loader/impl/solver/QuiltRuleBreakAll.java
+++ b/src/main/java/org/quiltmc/loader/impl/solver/QuiltRuleBreakAll.java
@@ -27,19 +27,19 @@ import org.quiltmc.loader.api.ModDependency;
 public class QuiltRuleBreakAll extends QuiltRuleBreak {
 
 	final QuiltRuleBreakOnly[] options;
-	final ModDependency.All publicDep;
+	final ModDependency.Any publicDep;
 
-	public QuiltRuleBreakAll(Logger logger, RuleContext ctx, LoadOption option, ModDependency.All all) {
+	public QuiltRuleBreakAll(Logger logger, RuleContext ctx, LoadOption option, ModDependency.Any all) {
 
 		super(option);
 		this.publicDep = all;
 		List<QuiltRuleBreakOnly> optionList = new ArrayList<>();
 
-		for (ModDependency.Only only : all) {
-			if (!only.shouldIgnore()) {
-				QuiltModDepOption sub = new QuiltModDepOption(only);
+		for (ModDependency.Entry entry : all) {
+			if (!entry.shouldIgnore()) {
+				QuiltModDepOption sub = new QuiltModDepOption(entry);
 				ctx.addOption(sub);
-				QuiltRuleBreakOnly dep = new QuiltRuleBreakOnly(logger, ctx, sub, only);
+				QuiltRuleBreakOnly dep = new QuiltRuleBreakOnly(logger, ctx, sub, entry);
 				ctx.addRule(dep);
 				optionList.add(dep);
 			}

--- a/src/main/java/org/quiltmc/loader/impl/solver/QuiltRuleBreakOnly.java
+++ b/src/main/java/org/quiltmc/loader/impl/solver/QuiltRuleBreakOnly.java
@@ -27,14 +27,14 @@ import org.quiltmc.loader.api.ModDependency;
 class QuiltRuleBreakOnly extends QuiltRuleBreak {
 	final Logger logger;
 
-	final ModDependency.Only publicDep;
+	final ModDependency.Entry publicDep;
 	final List<ModLoadOption> conflictingOptions;
 	final List<ModLoadOption> okayOptions;
 	final List<ModLoadOption> allOptions;
 
 	final QuiltRuleDep unless;
 
-	public QuiltRuleBreakOnly(Logger logger, RuleContext ctx, LoadOption source, ModDependency.Only publicDep) {
+	public QuiltRuleBreakOnly(Logger logger, RuleContext ctx, LoadOption source, ModDependency.Entry publicDep) {
 		super(source);
 		this.logger = logger;
 		this.publicDep = publicDep;

--- a/src/main/java/org/quiltmc/loader/impl/solver/QuiltRuleDepAny.java
+++ b/src/main/java/org/quiltmc/loader/impl/solver/QuiltRuleDepAny.java
@@ -35,11 +35,11 @@ public class QuiltRuleDepAny extends QuiltRuleDep {
 		this.publicDep = any;
 		List<QuiltRuleDepOnly> optionList = new ArrayList<>();
 
-		for (ModDependency.Only only : any) {
-			if (!only.shouldIgnore()) {
-				QuiltModDepOption sub = new QuiltModDepOption(only);
+		for (ModDependency.Entry entry : any) {
+			if (!entry.shouldIgnore()) {
+				QuiltModDepOption sub = new QuiltModDepOption(entry);
 				ctx.addOption(sub);
-				QuiltRuleDepOnly dep = new QuiltRuleDepOnly(logger, ctx, sub, only);
+				QuiltRuleDepOnly dep = new QuiltRuleDepOnly(logger, ctx, sub, entry);
 				ctx.addRule(dep);
 				optionList.add(dep);
 			}

--- a/src/main/java/org/quiltmc/loader/impl/solver/QuiltRuleDepOnly.java
+++ b/src/main/java/org/quiltmc/loader/impl/solver/QuiltRuleDepOnly.java
@@ -27,14 +27,14 @@ import org.quiltmc.loader.api.ModDependency;
 class QuiltRuleDepOnly extends QuiltRuleDep {
 	final Logger logger;
 
-	final ModDependency.Only publicDep;
+	final ModDependency.Entry publicDep;
 	final List<ModLoadOption> validOptions;
 	final List<ModLoadOption> invalidOptions;
 	final List<ModLoadOption> allOptions;
 
 	final QuiltRuleDep unless;
 
-	public QuiltRuleDepOnly(Logger logger, RuleContext ctx, LoadOption source, ModDependency.Only publicDep) {
+	public QuiltRuleDepOnly(Logger logger, RuleContext ctx, LoadOption source, ModDependency.Entry publicDep) {
 		super(source);
 		this.logger = logger;
 		this.publicDep = publicDep;


### PR DESCRIPTION
These changes are in line with what upstream Fabric did to their ModDependency. However, I did change a few things:
- The method to get all mod "dependencies" is called `relations()`, because in the future it may be expanded to hold a `ModDependency` that isn't necessarily a hard dependency. (For example, we could add a `conflicts` option like fabric v1, which gives a warning screen on first launch but allows you to continue). I'd be willing to rename `relations()` to `dependencies()`, or rename `ModDependency` to `ModRelation`, if that would be clearer.
- I've removed `depends()` and `breaks()` in line with upstream, which recommends getting all relations then filtering on the `Kind` you want. I'm not sure if this is the best approach though and I'm willing to add those methods back.

I will rebase this PR onto my massive upstream update branch if approved.