### PR TITLE
Fix Manifest Entrypoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,7 +148,7 @@ task fatJar(type: ShadowJar, dependsOn: getSat4jAbout) {
 
 	manifest {
 		attributes (
-			"Main-Class": "org.quiltmc.impl.launch.server.QuiltServerLauncher"
+			"Main-Class": "org.quiltmc.loader.impl.launch.server.QuiltServerLauncher"
 		)
 	}
 


### PR DESCRIPTION
No such package: `org.quiltmc.impl`. It's actually `org.quiltmc.loader.impl`.