### PR TITLE
Add `intermediate_mappings` field to `quilt.mod.json`

### DIFF
--- a/minecraft-test/src/main/resources/quilt.mod.json
+++ b/minecraft-test/src/main/resources/quilt.mod.json
@@ -4,6 +4,7 @@
         "group": "org.quiltmc.test",
         "id": "minecraft-test",
         "version": "1.0.0",
+        "intermediate_mappings": "net.fabricmc:intermediary",
         "entrypoints": {
             "preLaunch": [
                 "org.quiltmc.test.PrelaunchTest"

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/FabricModMetadataWrapper.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/FabricModMetadataWrapper.java
@@ -274,7 +274,7 @@ public class FabricModMetadataWrapper implements InternalModMetadata {
 
 	@Override
 	public String intermediateMappings() {
-		return "intermediary";
+		return "net.fabricmc:intermediary";
 	}
 
 	@Override

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/FabricModMetadataWrapper.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/FabricModMetadataWrapper.java
@@ -273,6 +273,11 @@ public class FabricModMetadataWrapper implements InternalModMetadata {
 	}
 
 	@Override
+	public String intermediateMappings() {
+		return "intermediary";
+	}
+
+	@Override
 	public @Nullable String icon(int size) {
 		return fabricMeta.getIconPath(size).orElse(null);
 	}

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/InternalModMetadata.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/InternalModMetadata.java
@@ -41,6 +41,8 @@ public interface InternalModMetadata extends ModMetadata, ModMetadataToBeMovedTo
 
 	Collection<String> repositories();
 
+	String intermediateMappings();
+
 
 	@Override
 	default FabricLoaderModMetadata asFabricModMetadata() {

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/Patterns.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/Patterns.java
@@ -24,6 +24,7 @@ import java.util.regex.Pattern;
 final class Patterns {
 	public static final Pattern VALID_MOD_ID = Pattern.compile("^[a-z][a-z0-9-_]{1,63}$");
 	public static final Pattern VALID_MAVEN_GROUP = Pattern.compile("^[a-zA-Z0-9-_.]+$");
+	public static final Pattern VALID_INTERMEDIATE = Pattern.compile("^[a-zA-Z0-9-_.]+:[a-zA-Z0-9-_.]+$");
 	public static final Pattern VERSION_PLACEHOLDER = Pattern.compile("^[a-zA-Z0-9-_.]+$");
 
 	private Patterns() {

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/V1ModMetadataImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/V1ModMetadataImpl.java
@@ -42,6 +42,7 @@ final class V1ModMetadataImpl implements InternalModMetadata {
 	private final Map<String, String> contactInformation;
 	private final Collection<ModDependency> depends;
 	private final Collection<ModDependency> breaks;
+	private final String intermediateMappings;
 	private final Icons icons;
 	/* Internal fields */
 	private final ModLoadType loadType;
@@ -68,6 +69,7 @@ final class V1ModMetadataImpl implements InternalModMetadata {
 			Map<String, String> contactInformation,
 			Collection<ModDependency> depends,
 			Collection<ModDependency> breaks,
+			String intermediateMappings,
 			@Nullable Icons icons,
 			/* Internal fields */
 			ModLoadType loadType,
@@ -107,6 +109,7 @@ final class V1ModMetadataImpl implements InternalModMetadata {
 		this.contactInformation = Collections.unmodifiableMap(contactInformation);
 		this.depends = Collections.unmodifiableCollection(depends);
 		this.breaks = Collections.unmodifiableCollection(breaks);
+		this.intermediateMappings = intermediateMappings;
 
 		if (icons != null) {
 			this.icons = icons;
@@ -183,6 +186,11 @@ final class V1ModMetadataImpl implements InternalModMetadata {
 	@Override
 	public Collection<ModDependency> breaks() {
 		return this.breaks;
+	}
+
+	@Override
+	public String intermediateMappings() {
+		return this.intermediateMappings;
 	}
 
 	@Nullable

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/V1ModMetadataReader.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/V1ModMetadataReader.java
@@ -241,8 +241,8 @@ final class V1ModMetadataReader {
 			@Nullable
 			JsonLoaderValue intermediateMappingsValue = quiltLoader.get("intermediate_mappings");
 
-			String[] supported_mappings = { "hashed", "intermediary" };
-			String mappings;
+			String[] supported_mappings = { "org.quiltmc:hashed", "net.fabricmc:intermediary" };
+			String mappings = "org.quiltmc:hashed";
 
 			if (intermediateMappingsValue != null) {
 				if (intermediateMappingsValue.type() != LoaderValue.LType.STRING) {
@@ -251,15 +251,17 @@ final class V1ModMetadataReader {
 
 				mappings = intermediateMappingsValue.asString();
 
+				if (!Patterns.VALID_INTERMEDIATE.matcher(mappings).matches()) {
+					throw parseException(intermediateMappingsValue, "intermediate_mappings must be a valid maven coordinate");
+				}
+
 				if (!Arrays.asList(supported_mappings).contains(mappings)) {
 					throw parseException(intermediateMappingsValue, "unknown intermediate mappings");
 				}
-			} else {
-				mappings = "hashed";
 			}
 
 			// Until Loader supports hashed mappings
-			if (mappings.equals("hashed")) {
+			if (mappings.equals("org.quiltmc:hashed")) {
 				throw new ParseException("Oh no! This version of Quilt Loader doesn't support hashed mappings, please update Quilt Loader to use this mod.");
 			}
 

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/V1ModMetadataReader.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/V1ModMetadataReader.java
@@ -61,6 +61,7 @@ final class V1ModMetadataReader {
 		Map<String, String> contactInformation = new LinkedHashMap<>();
 		List<ModDependency> depends = new ArrayList<>();
 		List<ModDependency> breaks = new ArrayList<>();
+		String intermediateMappings = "intermediary";
 		Icons icons = null;
 		/* Internal fields */
 		ModLoadType loadType = ModLoadType.IF_REQUIRED;
@@ -237,6 +238,21 @@ final class V1ModMetadataReader {
 				}
 			}
 
+			@Nullable
+			JsonLoaderValue intermediateMappingsValue = quiltLoader.get("intermediate_mappings");
+
+			if (intermediateMappingsValue != null) {
+				String mappings = string(quiltLoader, "intermediate_mappings");
+
+				if (mappings.equals("hashed")) {
+					throw parseException(intermediateMappingsValue, "Oh no! This version of Quilt Loader doesn't support hashed mappings, please update Quilt Loader to use this mod.");
+				} else if (!mappings.equals("intermediary")) {
+					throw parseException(intermediateMappingsValue, "unknown intermediate mappings");
+				}
+
+				intermediateMappings = mappings;
+			}
+
 			// Metadata
 			JsonLoaderValue metadataValue = quiltLoader.get("metadata");
 
@@ -356,6 +372,7 @@ final class V1ModMetadataReader {
 				contactInformation,
 				depends,
 				breaks,
+				intermediateMappings,
 				icons,
 				loadType,
 				provides,

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/V1ModMetadataReader.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/V1ModMetadataReader.java
@@ -241,20 +241,29 @@ final class V1ModMetadataReader {
 			@Nullable
 			JsonLoaderValue intermediateMappingsValue = quiltLoader.get("intermediate_mappings");
 
-			if (intermediateMappingsValue != null) {
-				String mappings = string(quiltLoader, "intermediate_mappings");
+			String[] supported_mappings = { "hashed", "intermediary" };
+			String mappings;
 
-				if (mappings.equals("hashed")) {
-					throw parseException(intermediateMappingsValue, "Oh no! This version of Quilt Loader doesn't support hashed mappings, please update Quilt Loader to use this mod.");
-				} else if (!mappings.equals("intermediary")) {
-					throw parseException(intermediateMappingsValue, "unknown intermediate mappings");
+			if (intermediateMappingsValue != null) {
+				if (intermediateMappingsValue.type() != LoaderValue.LType.STRING) {
+					throw parseException(intermediateMappingsValue, "intermediate_mappings must be a string");
 				}
 
-				intermediateMappings = mappings;
+				mappings = intermediateMappingsValue.asString();
+
+				if (!Arrays.asList(supported_mappings).contains(mappings)) {
+					throw parseException(intermediateMappingsValue, "unknown intermediate mappings");
+				}
 			} else {
-				// Fallback to default mappings
-				intermediateMappings = "hashed";
+				mappings = "hashed";
 			}
+
+			// Until Loader supports hashed mappings
+			if (mappings.equals("hashed")) {
+				throw new ParseException("Oh no! This version of Quilt Loader doesn't support hashed mappings, please update Quilt Loader to use this mod.");
+			}
+
+			intermediateMappings = mappings;
 
 			// Metadata
 			JsonLoaderValue metadataValue = quiltLoader.get("metadata");

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/V1ModMetadataReader.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/V1ModMetadataReader.java
@@ -61,7 +61,7 @@ final class V1ModMetadataReader {
 		Map<String, String> contactInformation = new LinkedHashMap<>();
 		List<ModDependency> depends = new ArrayList<>();
 		List<ModDependency> breaks = new ArrayList<>();
-		String intermediateMappings = "intermediary";
+		String intermediateMappings = null;
 		Icons icons = null;
 		/* Internal fields */
 		ModLoadType loadType = ModLoadType.IF_REQUIRED;
@@ -251,6 +251,9 @@ final class V1ModMetadataReader {
 				}
 
 				intermediateMappings = mappings;
+			} else {
+				// Fallback to default mappings
+				intermediateMappings = "hashed";
 			}
 
 			// Metadata

--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -5,6 +5,7 @@
     "id": "quilt_loader",
     "provides": [ "fabricloader" ],
     "version": "${version}",
+    "intermediate_mappings": "net.fabricmc:intermediary",
     "metadata": {
       "name": "Quilt Loader",
       "description": "The base mod loader.",

--- a/src/test/resources/testing/parsing/quilt/v1/auto/error/hashed_intermediate.json
+++ b/src/test/resources/testing/parsing/quilt/v1/auto/error/hashed_intermediate.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "quilt_loader": {
+    "group": "org.example",
+    "id": "some_id",
+    "version": "1.0.0",
+    "intermediate_mappings": "org.quiltmc:hashed",
+    "provides": [
+      {
+        "id": "another_mod"
+      }
+    ],
+    "depends": [
+      {
+        "id": "mod_two"
+      }
+    ]
+  }
+}

--- a/src/test/resources/testing/parsing/quilt/v1/auto/error/missing_intermediate.json
+++ b/src/test/resources/testing/parsing/quilt/v1/auto/error/missing_intermediate.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "quilt_loader": {
+    "group": "org.example",
+    "id": "some_id",
+    "version": "1.0.0",
+    "provides": [
+      {
+        "id": "another_mod"
+      }
+    ],
+    "depends": [
+      {
+        "id": "mod_two"
+      }
+    ]
+  }
+}

--- a/src/test/resources/testing/parsing/quilt/v1/auto/error/missing_schema.json
+++ b/src/test/resources/testing/parsing/quilt/v1/auto/error/missing_schema.json
@@ -3,6 +3,7 @@
     "group": "org.example",
     "id": "some_id",
     "version": "1.0.0",
+    "intermediate_mappings": "net.fabricmc:intermediary",
     "provides": [
       {
         "id": "another_mod"

--- a/src/test/resources/testing/parsing/quilt/v1/auto/error/random_intermediate.json
+++ b/src/test/resources/testing/parsing/quilt/v1/auto/error/random_intermediate.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "quilt_loader": {
+    "group": "org.example",
+    "id": "some_id",
+    "version": "1.0.0",
+    "intermediate_mappings": "blah.blah:blah",
+    "provides": [
+      {
+        "id": "another_mod"
+      }
+    ],
+    "depends": [
+      {
+        "id": "mod_two"
+      }
+    ]
+  }
+}

--- a/src/test/resources/testing/parsing/quilt/v1/auto/spec/optional_fields.json
+++ b/src/test/resources/testing/parsing/quilt/v1/auto/spec/optional_fields.json
@@ -4,6 +4,7 @@
     "group": "org.example",
     "id": "some_id",
     "version": "1.0.0",
+    "intermediate_mappings": "net.fabricmc:intermediary",
     "provides": [
       {
         "id": "another_mod"

--- a/src/test/resources/testing/parsing/quilt/v1/auto/spec/valid_intermediate.json
+++ b/src/test/resources/testing/parsing/quilt/v1/auto/spec/valid_intermediate.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "quilt_loader": {
+    "group": "org.example",
+    "id": "some_id",
+    "version": "1.0.0",
+    "intermediate_mappings": "net.fabricmc:intermediary",
+    "provides": [
+      {
+        "id": "another_mod"
+      }
+    ],
+    "depends": [
+      {
+        "id": "mod_two"
+      }
+    ]
+  }
+}

--- a/src/test/resources/testing/resolving/error/multi_breaks/normal.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/error/multi_breaks/normal.jar/quilt.mod.json
@@ -4,6 +4,7 @@
     "group": "org.example",
     "id": "normal",
     "version": "1.0.0",
+    "intermediate_mappings": "net.fabricmc:intermediary",
     "breaks": [
         [ "part_1", "part_2" ]
     ]

--- a/src/test/resources/testing/resolving/error/multi_breaks/part_1.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/error/multi_breaks/part_1.jar/quilt.mod.json
@@ -3,6 +3,7 @@
   "quilt_loader": {
     "group": "org.example",
     "id": "part_1",
-    "version": "1.0.0"
+    "version": "1.0.0",
+    "intermediate_mappings": "net.fabricmc:intermediary"
   }
 }

--- a/src/test/resources/testing/resolving/error/multi_breaks/part_2.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/error/multi_breaks/part_2.jar/quilt.mod.json
@@ -3,6 +3,7 @@
   "quilt_loader": {
     "group": "org.example",
     "id": "part_2",
-    "version": "1.0.0"
+    "version": "1.0.0",
+    "intermediate_mappings": "net.fabricmc:intermediary"
   }
 }

--- a/src/test/resources/testing/resolving/valid/dep_gte/library.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/dep_gte/library.jar/quilt.mod.json
@@ -3,6 +3,7 @@
     "quilt_loader": {
         "group": "org.example",
         "id": "mod-resolving-tests-library",
-        "version": "1.0.0"
+        "version": "1.0.0",
+        "intermediate_mappings": "net.fabricmc:intermediary"
     }
 }

--- a/src/test/resources/testing/resolving/valid/dep_gte/main.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/dep_gte/main.jar/quilt.mod.json
@@ -4,6 +4,7 @@
         "group": "org.example",
         "id": "mod-resolving-tests-main",
         "version": "1.0.0",
+        "intermediate_mappings": "net.fabricmc:intermediary",
         "depends": [
             {"id": "mod-resolving-tests-library", "versions": ">=1.0.0"}
         ]

--- a/src/test/resources/testing/resolving/valid/extra_libs/main.jar/library.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/extra_libs/main.jar/library.jar/quilt.mod.json
@@ -4,6 +4,7 @@
         "group": "org.quiltmc",
         "id": "mod-resolving-tests-library",
         "version": "1.0.0",
-        "load_type": "if_required"
+        "load_type": "if_required",
+        "intermediate_mappings": "net.fabricmc:intermediary"
     }
 }

--- a/src/test/resources/testing/resolving/valid/extra_libs/main.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/extra_libs/main.jar/quilt.mod.json
@@ -5,6 +5,7 @@
         "id": "mod-resolving-tests-main",
         "version": "1.0.0",
         "depends": [],
-        "jars": [ "library.jar" ]
+        "jars": [ "library.jar" ],
+        "intermediate_mappings": "net.fabricmc:intermediary"
     }
 }

--- a/src/test/resources/testing/resolving/valid/groups/one.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/groups/one.jar/quilt.mod.json
@@ -4,6 +4,7 @@
         "group": "one",
         "id": "mod_one",
         "version": "1.0.0",
+        "intermediate_mappings": "net.fabricmc:intermediary",
         "breaks": [{
             "id": "dep",
             "unless": "one:dep"

--- a/src/test/resources/testing/resolving/valid/groups/provides.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/groups/provides.jar/quilt.mod.json
@@ -4,6 +4,7 @@
         "group": "combine",
         "id": "dep",
         "version": "1.0.0",
+        "intermediate_mappings": "net.fabricmc:intermediary",
         "provides": [
             "one:dep",
             "two:dep",

--- a/src/test/resources/testing/resolving/valid/groups/two.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/groups/two.jar/quilt.mod.json
@@ -4,6 +4,7 @@
         "group": "two",
         "id": "mod_two",
         "version": "1.0.0",
+        "intermediate_mappings": "net.fabricmc:intermediary",
         "breaks": [
             {
                 "id": "dep",

--- a/src/test/resources/testing/resolving/valid/qsl_provides/mod.jar/fabric-crash-handler.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/qsl_provides/mod.jar/fabric-crash-handler.jar/quilt.mod.json
@@ -3,6 +3,7 @@
     "quilt_loader": {
         "group": "org.quiltmc.test",
         "id": "fabric-crash-handler",
-        "version": "1.0.0"
+        "version": "1.0.0",
+        "intermediate_mappings": "net.fabricmc:intermediary"
     }
 }

--- a/src/test/resources/testing/resolving/valid/qsl_provides/mod.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/qsl_provides/mod.jar/quilt.mod.json
@@ -4,6 +4,7 @@
         "group": "org.quiltmc.test",
         "id": "a_mod",
         "version": "1.0.0",
+        "intermediate_mappings": "net.fabricmc:intermediary",
         "depends": [ "fabric-crash-handler" ],
         "jars": [ "fabric-crash-handler.jar" ]
     }

--- a/src/test/resources/testing/resolving/valid/qsl_provides/qsl.jar/quilt-crash-handler.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/qsl_provides/qsl.jar/quilt-crash-handler.jar/quilt.mod.json
@@ -4,6 +4,7 @@
         "group": "org.quiltmc.test",
         "id": "quilt-crash-handler",
         "version": "1.0.0",
+        "intermediate_mappings": "net.fabricmc:intermediary",
         "provides": [ "fabric-crash-handler" ]
     }
 }

--- a/src/test/resources/testing/resolving/valid/qsl_provides/qsl.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/qsl_provides/qsl.jar/quilt.mod.json
@@ -4,6 +4,7 @@
         "group": "org.quiltmc.test",
         "id": "quilt-standard-libraries",
         "version": "1.0.0",
+        "intermediate_mappings": "net.fabricmc:intermediary",
         "jars": [ "quilt-crash-handler.jar" ]
     }
 }

--- a/src/test/resources/testing/resolving/valid/quilt/main.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/quilt/main.jar/quilt.mod.json
@@ -3,6 +3,7 @@
     "quilt_loader": {
         "group": "org.quiltmc.test",
         "id": "mod-resolving-tests-quilt",
-        "version": "1.0.0"
+        "version": "1.0.0",
+        "intermediate_mappings": "net.fabricmc:intermediary"
     }
 }

--- a/src/test/resources/testing/resolving/valid/quilt_included_dep/main.jar/library.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/quilt_included_dep/main.jar/library.jar/quilt.mod.json
@@ -4,6 +4,7 @@
         "group": "org.quiltmc.test",
         "id": "mod-resolving-tests-library",
         "version": "1.0.0",
-        "load_type": "if_required"
+        "load_type": "if_required",
+        "intermediate_mappings": "net.fabricmc:intermediary"
     }
 }

--- a/src/test/resources/testing/resolving/valid/quilt_included_dep/main.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/quilt_included_dep/main.jar/quilt.mod.json
@@ -5,6 +5,7 @@
         "id": "mod-resolving-tests-main",
         "version": "1.0.0",
         "jars": [ "library.jar" ],
-        "depends": [ "mod-resolving-tests-library" ]
+        "depends": [ "mod-resolving-tests-library" ],
+        "intermediate_mappings": "net.fabricmc:intermediary"
     }
 }

--- a/src/test/resources/testing/resolving/valid/quilt_included_provided/main.jar/library.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/quilt_included_provided/main.jar/library.jar/quilt.mod.json
@@ -5,6 +5,7 @@
         "id": "mod-resolving-tests-better-library",
         "provides": [ "mod-resolving-tests-library" ],
         "version": "1.0.0",
-        "load_type": "if_required"
+        "load_type": "if_required",
+        "intermediate_mappings": "net.fabricmc:intermediary"
     }
 }

--- a/src/test/resources/testing/resolving/valid/quilt_included_provided/main.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/quilt_included_provided/main.jar/quilt.mod.json
@@ -5,6 +5,7 @@
         "id": "mod-resolving-tests-main",
         "version": "1.0.0",
         "jars": [ "library.jar" ],
-        "depends": [ "mod-resolving-tests-library" ]
+        "depends": [ "mod-resolving-tests-library" ],
+        "intermediate_mappings": "net.fabricmc:intermediary"
     }
 }

--- a/src/test/resources/testing/resolving/valid/quilt_load_type/main.jar/library.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/quilt_load_type/main.jar/library.jar/quilt.mod.json
@@ -4,6 +4,7 @@
         "group": "org.quiltmc.test",
         "id": "mod-resolving-tests-library",
         "version": "1.0.0",
-        "load_type": "if_required"
+        "load_type": "if_required",
+        "intermediate_mappings": "net.fabricmc:intermediary"
     }
 }

--- a/src/test/resources/testing/resolving/valid/quilt_load_type/main.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/quilt_load_type/main.jar/quilt.mod.json
@@ -4,6 +4,7 @@
         "group": "org.quiltmc.test",
         "id": "mod-resolving-tests-main",
         "version": "1.0.0",
-        "jars": [ "library.jar" ]
+        "jars": [ "library.jar" ],
+        "intermediate_mappings": "net.fabricmc:intermediary"
     }
 }

--- a/src/test/resources/testing/resolving/valid/sub_mod/main.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/sub_mod/main.jar/quilt.mod.json
@@ -5,6 +5,7 @@
         "id": "mod-resolving-tests-main",
         "version": "1.0.0",
         "depends": [],
-        "jars": [ "sub.jar" ]
+        "jars": [ "sub.jar" ],
+        "intermediate_mappings": "net.fabricmc:intermediary"
     }
 }

--- a/src/test/resources/testing/resolving/valid/sub_mod/main.jar/sub.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/sub_mod/main.jar/sub.jar/quilt.mod.json
@@ -4,6 +4,7 @@
         "group": "org.quiltmc",
         "id": "mod-resolving-tests-sub",
         "version": "1.0.0",
-        "load_type": "always"
+        "load_type": "always",
+        "intermediate_mappings": "net.fabricmc:intermediary"
     }
 }


### PR DESCRIPTION
Fixes #59

Adds the ability to declare the intermediate mappings a mod uses in the `quilt.mod.json` file.