### PR TITLE
Fix: Update asm to 9.3 to fix crash caused by LWJGL 3.3.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,5 @@ group = org.quiltmc
 description = The mod loading component of Quilt
 url = https://github.com/quiltmc/quilt-loader
 
-asm_version = 9.2
+asm_version = 9.3
 mixin_version = 0.11.2+mixin.0.8.5

--- a/src/main/resources/fabric-installer.launchwrapper.json
+++ b/src/main/resources/fabric-installer.launchwrapper.json
@@ -24,23 +24,23 @@
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm:9.2",
+        "name": "org.ow2.asm:asm:9.3",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-analysis:9.2",
+        "name": "org.ow2.asm:asm-analysis:9.3",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-commons:9.2",
+        "name": "org.ow2.asm:asm-commons:9.3",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-tree:9.2",
+        "name": "org.ow2.asm:asm-tree:9.3",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-util:9.2",
+        "name": "org.ow2.asm:asm-util:9.3",
         "url": "https://maven.fabricmc.net/"
       }
     ],

--- a/src/main/resources/quilt_installer.json
+++ b/src/main/resources/quilt_installer.json
@@ -25,23 +25,23 @@
         "url": "https://maven.quiltmc.org/repository/release/"
       },
       {
-        "name": "org.ow2.asm:asm:9.2",
+        "name": "org.ow2.asm:asm:9.3",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-analysis:9.2",
+        "name": "org.ow2.asm:asm-analysis:9.3",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-commons:9.2",
+        "name": "org.ow2.asm:asm-commons:9.3",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-tree:9.2",
+        "name": "org.ow2.asm:asm-tree:9.3",
         "url": "https://maven.fabricmc.net/"
       },
       {
-        "name": "org.ow2.asm:asm-util:9.2",
+        "name": "org.ow2.asm:asm-util:9.3",
         "url": "https://maven.fabricmc.net/"
       }
     ],


### PR DESCRIPTION
Without this patch, Minecraft>=22w16a crashes as asm<9.3 doesn't support Java 19, and LWJGL 3.3.1 includes Java 19 classes.