### PR TITLE
Sort modlist in logs alphabetically (#68)

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -25,6 +25,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 
 import org.objectweb.asm.Opcodes;
@@ -222,7 +224,7 @@ public final class QuiltLoaderImpl {
 
 		StringBuilder modListText = new StringBuilder();
 
-		for (ModCandidate mod : modCandidates) {
+		for (ModCandidate mod : modCandidates.stream().sorted(Comparator.comparing(ModCandidate::getId)).collect(Collectors.toList())) {
 			if (modListText.length() > 0) modListText.append('\n');
 
 			modListText.append("\t- ");


### PR DESCRIPTION
We do a lil' streamin'

Only sorts the list used in the for loop since I wasn't sure whether I should change the order of the actual mod candidate list (because of dependencies).

Closes #68.