### PR TITLE
Make sure mod id doesn't contain : when using mavenGroup:id format.

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/ModDependencyIdentifierImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/ModDependencyIdentifierImpl.java
@@ -26,7 +26,7 @@ public final class ModDependencyIdentifierImpl implements ModDependencyIdentifie
 		int split = raw.indexOf(":");
 		if (split > 0) {
 			mavenGroup = raw.substring(0, split);
-			id = raw.substring(split);
+			id = raw.substring(split + 1);
 		} else {
 			mavenGroup = "";
 			id = raw;


### PR DESCRIPTION
Basically using the following would try to look up `org.quiltmc::quilt_loader` rather than `org.quiltmc:quilt_loader`

```
"depends": [
      "org.quiltmc:quilt_loader",
]
```

Example error message:
![image](https://user-images.githubusercontent.com/5214513/164981769-b3fa5e4e-3229-4b11-8c1b-2315539169ad.png)
