### PR TITLE
Properly select mods in the mods folder over nested jars

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/discovery/ModCandidateSet.java
+++ b/src/main/java/org/quiltmc/loader/impl/discovery/ModCandidateSet.java
@@ -37,6 +37,13 @@ public class ModCandidateSet {
 	private final Map<String, ModCandidate> candidates = new HashMap<>();
 
 	private static int compare(ModCandidate a, ModCandidate b) {
+		// Mandatory mods are always first
+		if (a.getDepth() == 0) {
+			return -1;
+		} else if (b.getDepth() == 0) {
+			return 1;
+		}
+
 		Version av = a.getInfo().getVersion();
 		Version bv = b.getInfo().getVersion();
 

--- a/src/main/java/org/quiltmc/loader/impl/discovery/RuntimeModRemapper.java
+++ b/src/main/java/org/quiltmc/loader/impl/discovery/RuntimeModRemapper.java
@@ -143,7 +143,7 @@ public final class RuntimeModRemapper {
 				}
 				// TODO: intentional leak?
 				FileSystemUtil.FileSystemDelegate jarFs = FileSystemUtil.getJarFileSystem(info.outputPath, false);
-				remappedMods.add(new ModCandidate(mod.getOriginPath(), jarFs.get().getPath("/"), mod.getInfo(), 0, false));
+				remappedMods.add(new ModCandidate(mod.getOriginPath(), jarFs.get().getPath("/"), mod.getInfo(), mod.getDepth(), false));
 			}
 
 		} catch (IOException e) {


### PR DESCRIPTION
I'm 99% sure this is the right place for this fix, but since this isn't my domain of code at all I want to make sure I did it right.

This changes behavior to match expectations--if you place a mod in the mods folder, then that version will now always be selected over a JiJ'd mod with the same ID.