### PR TITLE
Keep Mixin 0.9.2 compatible mods first in the load order

### DIFF
--- a/src/main/java/net/fabricmc/loader/launch/common/FabricMixinBootstrap.java
+++ b/src/main/java/net/fabricmc/loader/launch/common/FabricMixinBootstrap.java
@@ -130,7 +130,7 @@ public final class FabricMixinBootstrap {
 		initialized = true;
 	}
 
-	private static final class MixinConfigDecorator {
+	public static final class MixinConfigDecorator {
 		private static final List<LoaderMixinVersionEntry> versions = new ArrayList<>();
 
 		static {
@@ -152,7 +152,7 @@ public final class FabricMixinBootstrap {
 			}
 		}
 
-		private static int getMixinCompat(ModContainerImpl mod) {
+		public static int getMixinCompat(ModContainerImpl mod) {
 			// infer from loader dependency by determining the least relevant loader version the mod accepts
 			// AND any loader deps
 


### PR DESCRIPTION
This PR is a temporary fix for https://github.com/FabricMC/Mixin/issues/89. Forcing 0.9.2-compatible mods to be loaded first should stop local variables from leaking into mods using incompatible versions of Mixin.