### PR TITLE
Fix multiline comment spacing on TOML configs

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/config/NightConfigSerializer.java
+++ b/src/main/java/org/quiltmc/loader/impl/config/NightConfigSerializer.java
@@ -111,7 +111,9 @@ public final class NightConfigSerializer<C extends CommentedConfig> implements S
 
 			if (node.hasMetadata(Comment.TYPE)) {
 				for (String string : node.metadata(Comment.TYPE)) {
-					string.lines().forEach(line -> comments.add(line));
+					for (String line : string.split("\n")) {
+						comments.add(line);
+					}
 				}
 			}
 

--- a/src/main/java/org/quiltmc/loader/impl/config/NightConfigSerializer.java
+++ b/src/main/java/org/quiltmc/loader/impl/config/NightConfigSerializer.java
@@ -111,7 +111,7 @@ public final class NightConfigSerializer<C extends CommentedConfig> implements S
 
 			if (node.hasMetadata(Comment.TYPE)) {
 				for (String string : node.metadata(Comment.TYPE)) {
-					comments.add(string);
+					string.lines().forEach(line -> comments.add(line));
 				}
 			}
 


### PR DESCRIPTION
This PR fixes multiline comments on TOML not having the one space padding on their other lines