### PR TITLE
Bump provided Fabric Loader to 0.14.8, standardize the metadata

### DIFF
--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -3,17 +3,12 @@
   "quilt_loader": {
     "group": "org.quiltmc",
     "id": "quilt_loader",
-    "provides": [ {
-      "id": "fabricloader",
-      "version": "0.14.7"
-    } ],
     "version": "${version}",
-    "intermediate_mappings": "net.fabricmc:intermediary",
     "metadata": {
       "name": "Quilt Loader",
-      "description": "The base mod loader.",
+      "description": "The mod-loader that cares.",
       "contributors": {
-        "QuiltMC": "Owner"
+        "QuiltMC: Loader Team": "Owner"
       },
       "contact": {
         "homepage": "https://quiltmc.org",
@@ -22,6 +17,13 @@
       },
       "license": "Apache-2.0",
       "icon": "assets/quilt_loader/icon.png"
-    }
+    },
+    "intermediate_mappings": "net.fabricmc:intermediary",
+    "provides": [
+      {
+        "id": "fabricloader",
+        "version": "0.14.8"
+      }
+    ]
   }
 }


### PR DESCRIPTION
This PR updates the provided FLoader to 0.14.8, considering that the mandatory parity change, the entrypoint patch update, has already been implemented

Also, I took the opportunity to standardize the QMJ to follow the QTM/Quilted FAPI ones, and also replace the description with the Quilt toolchain's slogan, because keeping Fabric stuff is bad and consistency is good