### PR TITLE
Bump mixin version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ description = The mod loading component of Quilt
 url = https://github.com/quiltmc/quilt-loader
 
 asm_version = 9.3
-mixin_version = 0.11.2+mixin.0.8.5
+mixin_version = 0.11.4+mixin.0.8.5


### PR DESCRIPTION
Quilt Loader has been using an outdated version of mixin causing injections to capture local variables incorrectly. This issue was fixed in mixin version 0.11.3 thus bumping mixin to the latest version (`0.11.4+mixin.0.8.5`) fixes this issue.