### PR TITLE
Update optional dependencies to actually be useful

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/solver/QuiltRuleDepOnly.java
+++ b/src/main/java/org/quiltmc/loader/impl/solver/QuiltRuleDepOnly.java
@@ -101,10 +101,16 @@ class QuiltRuleDepOnly extends QuiltRuleDep {
 	void define(RuleDefiner definer) {
 
 		boolean optional = publicDep.optional();
-		List<ModLoadOption> options = optional ? invalidOptions : validOptions;
+		List<ModLoadOption> options = validOptions;
+		boolean negateOptions = false;
 
 		if (optional && options.isEmpty()) {
-			return;
+			options = invalidOptions;
+			negateOptions = true;
+
+			if (options.isEmpty()) {
+				return;
+			}
 		}
 
 		LoadOption[] array = new LoadOption[options.size() + (unless == null ? 1 : 2)];
@@ -112,7 +118,7 @@ class QuiltRuleDepOnly extends QuiltRuleDep {
 
 		for (; i < options.size(); i++) {
 			array[i] = options.get(i);
-			if (optional) {
+			if (negateOptions) {
 				array[i] = definer.negate(array[i]);
 			}
 		}

--- a/src/test/java/net/fabricmc/test/ModResolvingTests.java
+++ b/src/test/java/net/fabricmc/test/ModResolvingTests.java
@@ -100,6 +100,15 @@ final class ModResolvingTests {
 	}
 
 	@Test
+	public void lowBreaks() throws Exception {
+		ModSolveResult modSet = resolveModSet("valid", "lowbreaks");
+
+		assertModPresent(modSet, "mod-resolving-tests-main", "1.0.0");
+		assertModPresent(modSet, "mod-resolving-tests-optional", "1.19-1.0.6");
+		assertNoMoreMods(modSet);
+	}
+
+	@Test
 	public void altDep() throws Exception {
 		// Run the test multiple times to ensure we always pick the right dep
 		// (and also makes sure we never mess up)
@@ -204,6 +213,15 @@ final class ModResolvingTests {
 		assertModPresent(modSet, "mod-resolving-tests-main", "1.0.0");
 		assertModPresent(modSet, "mod-resolving-tests-better-library", "1.0.0");
 		assertProvidedPresent(modSet, "mod-resolving-tests-library", "1.0.0");
+		assertNoMoreMods(modSet);
+	}
+
+	@Test
+	public void quiltIncludedOptional() throws Exception {
+		ModSolveResult modSet = resolveModSet("valid", "quilt_included_optional");
+
+		assertModPresent(modSet, "mod-resolving-tests-main", "1.0.0");
+		assertModPresent(modSet, "mod-resolving-tests-optional-library", "1.0.0");
 		assertNoMoreMods(modSet);
 	}
 

--- a/src/test/resources/testing/resolving/valid/lowbreaks/mod.jar/fabric.mod.json
+++ b/src/test/resources/testing/resolving/valid/lowbreaks/mod.jar/fabric.mod.json
@@ -1,0 +1,8 @@
+{
+    "schemaVersion": 1,
+    "id": "mod-resolving-tests-main",
+    "version": "1.0.0",
+    "breaks": {
+        "mod-resolving-tests-optional": "<1.18.2-1.0.5"
+    }
+}

--- a/src/test/resources/testing/resolving/valid/lowbreaks/optional.jar/fabric.mod.json
+++ b/src/test/resources/testing/resolving/valid/lowbreaks/optional.jar/fabric.mod.json
@@ -1,0 +1,5 @@
+{
+    "schemaVersion": 1,
+    "id": "mod-resolving-tests-optional",
+    "version": "1.19-1.0.6"
+}

--- a/src/test/resources/testing/resolving/valid/quilt_included_optional/main.jar/library.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/quilt_included_optional/main.jar/library.jar/quilt.mod.json
@@ -1,0 +1,10 @@
+{
+    "schema_version": 1,
+    "quilt_loader": {
+        "group": "org.quiltmc.test",
+        "id": "mod-resolving-tests-optional-library",
+        "version": "1.0.0",
+        "load_type": "if_required",
+        "intermediate_mappings": "net.fabricmc:intermediary"
+    }
+}

--- a/src/test/resources/testing/resolving/valid/quilt_included_optional/main.jar/quilt.mod.json
+++ b/src/test/resources/testing/resolving/valid/quilt_included_optional/main.jar/quilt.mod.json
@@ -1,0 +1,16 @@
+{
+    "schema_version": 1,
+    "quilt_loader": {
+        "group": "org.quiltmc.test",
+        "id": "mod-resolving-tests-main",
+        "version": "1.0.0",
+        "jars": [ "library.jar" ],
+        "depends": [
+            {
+                "id": "mod-resolving-tests-optional-library",
+                "optional": true
+            }
+        ],
+        "intermediate_mappings": "net.fabricmc:intermediary"
+    }
+}


### PR DESCRIPTION
Currently marking a dependency as `optional` is interpreted by loader (and the solver system) as an inverted breakage - so it will prevent you from loading an invalid version, however it won't actually *depend* on the correct version - which means the correct version might not get loaded.

This fixes that behavior - so now it both breaks if only invalid versions are present, permits no versions to be present, and depends on one of the valid versions if any are present.