### PR TITLE
Fix #90, URI encoding issues

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/util/UrlUtil.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/UrlUtil.java
@@ -64,15 +64,15 @@ public final class UrlUtil {
 	public static Path asPath(URL url) {
 		try {
 			return Paths.get(
-					new URI(
-							url.getProtocol(),
-							url.getUserInfo(),
-							url.getHost(),
-							url.getPort(),
-							url.getPath(),
-							url.getQuery(),
-							null
-					)
+				new URI(
+					url.getProtocol(),
+					url.getUserInfo(),
+					url.getHost(),
+					url.getPort(),
+					url.getPath(),
+					url.getQuery(),
+					null
+				)
 			);
 		} catch (URISyntaxException e) {
 			throw ExceptionUtil.wrap(e);

--- a/src/main/java/org/quiltmc/loader/impl/util/UrlUtil.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/UrlUtil.java
@@ -19,6 +19,7 @@ package org.quiltmc.loader.impl.util;
 import java.io.File;
 import java.net.JarURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
@@ -62,7 +63,17 @@ public final class UrlUtil {
 
 	public static Path asPath(URL url) {
 		try {
-			return Paths.get(url.toURI());
+			return Paths.get(
+					new URI(
+							url.getProtocol(),
+							url.getUserInfo(),
+							url.getHost(),
+							url.getPort(),
+							url.getPath(),
+							url.getQuery(),
+							null
+					)
+			);
 		} catch (URISyntaxException e) {
 			throw ExceptionUtil.wrap(e);
 		}


### PR DESCRIPTION
The multi-argument constructor automatically escapes any invalid characters passed, so I just switched to that

Verified working in production
![image](https://user-images.githubusercontent.com/52360088/195434626-75ee0d6d-6c19-4251-a93c-3d18e0fc910b.png)

Github doesnt seem to have picked this up properly, so fixes #90 
