### PR TITLE
Revert "Fix #90, URI encoding issues"

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/util/UrlUtil.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/UrlUtil.java
@@ -19,7 +19,6 @@ package org.quiltmc.loader.impl.util;
 import java.io.File;
 import java.net.JarURLConnection;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
@@ -63,17 +62,7 @@ public final class UrlUtil {
 
 	public static Path asPath(URL url) {
 		try {
-			return Paths.get(
-				new URI(
-					url.getProtocol(),
-					url.getUserInfo(),
-					url.getHost(),
-					url.getPort(),
-					url.getPath(),
-					url.getQuery(),
-					null
-				)
-			);
+			return Paths.get(url.toURI());
 		} catch (URISyntaxException e) {
 			throw ExceptionUtil.wrap(e);
 		}


### PR DESCRIPTION
Thanks to a few people looking into the cause of #90 it looks like that was caused by ZipFileSystem not encoding things quite right - however since loader plugins don't use this, and the original fix causes a regression (#124) it's probably simplest to just revert #122?