### PR TITLE
Ignore sub-folders that start with a "."

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/plugin/QuiltPluginManagerImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/QuiltPluginManagerImpl.java
@@ -1585,6 +1585,11 @@ public class QuiltPluginManagerImpl implements QuiltPluginManager {
 							return FileVisitResult.SKIP_SUBTREE;
 						}
 
+						if (name.startsWith(".")) {  // ignore dot-folders
+							node.subIcon(node.manager().iconDisabled());
+							return FileVisitResult.SKIP_SUBTREE;
+						}
+
 						if (Files.exists(dir.resolve("quilt_loader_ignored"))) {
 							node.subIcon(node.manager().iconDisabled());
 							node.addChild(QuiltLoaderText.translate("warn.sub_folder_ignored"))


### PR DESCRIPTION
Prism Launcher stores mod metadata in `<instance root>/mods/.index`. Quilt tries to load the `.toml` files in there as mods.
I would propose to just ignore directories that start with a dot.

With this PR:
![Ignored .index with this PR](https://scrumplex.rocks/img/1667690756.png)

Without this PR:
![Quilt trying to load TOML files](https://scrumplex.rocks/img/1667690986.png)