### PR TITLE
Implement version-aware sorting for GenericVersionImpl

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/GenericVersionImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/GenericVersionImpl.java
@@ -19,6 +19,7 @@ package org.quiltmc.loader.impl.metadata.qmj;
 import org.quiltmc.loader.api.Version;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class GenericVersionImpl implements Version.Raw {
@@ -97,14 +98,16 @@ public class GenericVersionImpl implements Version.Raw {
 	 * of characters changes from numeric to non-numeric.
 	 */
 	private static List<Comparable<?>> decompose(String str) {
-		if (str.isEmpty()) return List.of();
+		if (str.isEmpty()) return Collections.emptyList();
 		boolean lastWasNumber = Character.isDigit(str.codePointAt(0));
 		StringBuilder accum = new StringBuilder();
 		List<Comparable<?>> out = new ArrayList<>();
 		// remove appendices
 		int plus = str.lastIndexOf('+');
 		if (plus != -1) str = str.substring(0, plus);
-		for (int cp : str.codePoints().toArray()) {
+		for (int i = 0; i < str.length(); i++) {
+			if (Character.isLowSurrogate(str.charAt(i))) continue;
+			int cp = str.codePointAt(i);
 			boolean number = Character.isDigit(cp);
 			if (number != lastWasNumber) {
 				complete(lastWasNumber, accum, out);

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/GenericVersionImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/GenericVersionImpl.java
@@ -53,10 +53,86 @@ public class GenericVersionImpl implements Version.Raw {
 	public int compareTo(Version other) {
 		return compareRaw(raw(), other.raw());
 	}
-
+	// it's difficult to generically deal with comparables - these operations are safe
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public static int compareRaw(String a, String b) {
-		// Ideally this would use number-aware comparison
-		// Oh well
-		return a.compareTo(b);
+		// Arrays.compare gives wrong precedence to array length, causing 1.0.1 to sort as older than 1.0.0_01
+		// so, implement it ourselves from scratch
+		List<Comparable<?>> ad = decompose(a);
+		List<Comparable<?>> bd = decompose(b);
+		for (int i = 0; i < Math.max(ad.size(), bd.size()); i++) {
+			Comparable ac = i >= ad.size() ? null : ad.get(i);
+			Comparable bc = i >= bd.size() ? null : bd.get(i);
+			if (typeof(ac) != typeof(bc)) {
+				// Comparables assume the input object is the same type as the object, so we need to
+				// ensure that's true; this will happen in the case of two critically mismatched
+				// versions that contain a symbol where a number is expected - in this case, lexical
+				// is the best we can do
+				ac = ac == null ? null : ac.toString();
+				bc = bc == null ? null : bc.toString();
+			}
+			int c;
+			if (bc == null && isSemverPrerelease(ac)) {
+				// special case: compatibility with semver, which sorts "pre-releases" differently
+				c = -1;
+			} else if (ac == null && isSemverPrerelease(bc)) {
+				c = 1;
+			} else if (ac == null) {
+				// special case: nulls are *always* lesser
+				// bc cannot be null here, don't need to check
+				c = -1;
+			} else {
+				c = bc == null ? 1 : ac.compareTo(bc);
+			}
+			if (c != 0) return c;
+		}
+		return 0;
+	}
+	
+	/*
+	 * Break apart a string into "logical" version components, by splitting it where a string
+	 * of characters changes from numeric to non-numeric.
+	 */
+	private static List<Comparable<?>> decompose(String str) {
+		if (str.isEmpty()) return List.of();
+		boolean lastWasNumber = Character.isDigit(str.codePointAt(0));
+		StringBuilder accum = new StringBuilder();
+		List<Comparable<?>> out = new ArrayList<>();
+		// remove appendices
+		int plus = str.lastIndexOf('+');
+		if (plus != -1) str = str.substring(0, plus);
+		for (int cp : str.codePoints().toArray()) {
+			boolean number = Character.isDigit(cp);
+			if (number != lastWasNumber) {
+				complete(lastWasNumber, accum, out);
+				lastWasNumber = number;
+			}
+			accum.appendCodePoint(cp);
+		}
+		complete(lastWasNumber, accum, out);
+		return out;
+	}
+
+	private static void complete(boolean number, StringBuilder accum, List<Comparable<?>> out) {
+		String s = accum.toString();
+		if (number) {
+			// just in case someone uses a pointlessly long version string...
+			out.add(Long.parseLong(s));
+		} else {
+			out.add(s);
+		}
+		accum.setLength(0);
+	}
+	
+	private static boolean isSemverPrerelease(Object o) {
+		if (o instanceof String) {
+			String s = (String)o;
+			return s.length() > 1 && s.charAt(0) == '-';
+		}
+		return false;
+	}
+
+	private static Class<?> typeof(Object o) {
+		return o == null ? null : o.getClass();
 	}
 }

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/GenericVersionImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/GenericVersionImpl.java
@@ -18,6 +18,9 @@ package org.quiltmc.loader.impl.metadata.qmj;
 
 import org.quiltmc.loader.api.Version;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class GenericVersionImpl implements Version.Raw {
 	private final String raw;
 

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/GenericVersionImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/GenericVersionImpl.java
@@ -103,7 +103,7 @@ public class GenericVersionImpl implements Version.Raw {
 		StringBuilder accum = new StringBuilder();
 		List<Comparable<?>> out = new ArrayList<>();
 		// remove appendices
-		int plus = str.lastIndexOf('+');
+		int plus = str.indexOf('+');
 		if (plus != -1) str = str.substring(0, plus);
 		for (int i = 0; i < str.length(); i++) {
 			if (Character.isLowSurrogate(str.charAt(i))) continue;


### PR DESCRIPTION
I heard QLoader was dropping the SemVer requirement. This is great, but the current implementation is a basic lexical sort on the version string. This is not ideal, and is no better than what FLoader does. (For "extended SemVer", which simply has additional segments, it is actually markedly *worse*.)

This PR implements what I call "FlexVer", a SemVer-compatible intuitive comparator for free-form versioning strings as seen in the wild. It's designed to sort versions like people do, rather than attempting to force conformance to a rigid and limited standard.

It works by splitting a string into "numeric" and "non-numeric" parts, and then sorting those lexically, with a few special cases for SemVer compatibility. This could, in theory, entirely replace Quilt's existing SemVer comparator — but I don't suggest this actually be done.

(This mode of operation is similar to how `sort -V` behaves in GNU coreutils.)

I have a test harness I used to verify this implementation is sound, visible in [the standalone implementation](https://github.com/unascribed/FlexVer/tree/trunk/java) — a screenshot of this harness follows:

![image](https://user-images.githubusercontent.com/6185037/200154644-b94b61bf-e430-4dbd-bd2e-caddab86c9f2.png)

Cyan is numeric, pink is non-numeric, red is SemVer pre-releases, and gray is ignored SemVer-style appendices. As the potential problem space of version number comparisons is infinite, I cannot devise a good way to truly verify this is a completely sound implementation; so, I simply cherry-picked some random examples of versions that I felt would trip up a version comparator, which both do and do not follow SemVer. As such, I also did not include a unit test; I feel a system like this only benefits from regression tests, after basic sanity tests done during development.

It is a non-goal for comparisons between versions of entirely different structures to "make sense" — but nonetheless, it does try its best and will normalize structural differences and fall back to lexical comparison when all else fails. Fundamentally, ***FlexVer does not impose any form of restrictions*** — it will always do its best to compare two strings and *never* throw an exception. If you do pass two completely different versions to it, well....

![image](https://user-images.githubusercontent.com/6185037/200155199-a80a03cf-9820-4075-9763-efff800e2507.png)

...the results won't necessarily make sense. Garbage in, garbage out.

There is **one known case where FlexVer and SemVer disagree**. It is related to pre-releases, as they are an exception to the intuitive version flow. There is a special case that makes the most common forms of them work, such as `-pre1`, `-rc2`, `-beta.2`, etc. However, this works by looking for a non-numeric component that starts with `-` and is longer than one character. As such, if you have a pre-release starting with a numeral, then FlexVer's normal parsing kicks in, which sorts `1.0.0` and `1.0.0-2` *in the opposite order that SemVer would*. However, I have never seen fully numeric pre-releases like this in the wild; a hyphenated numeric like that is generally meant to represent another "group" of versions — in which case, FlexVer does indeed sort it as expected.