### PR TITLE
Ignore mappings that don't contain target namespace

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/launch/common/MappingConfiguration.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/common/MappingConfiguration.java
@@ -104,10 +104,11 @@ public final class MappingConfiguration {
 
 				try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
 					long time = System.currentTimeMillis();
-					mappings = TinyMappingFactory.loadWithDetection(reader);
+					TinyTree mappings = TinyMappingFactory.loadWithDetection(reader);
 					Log.debug(LogCategory.MAPPINGS, "Loading mappings took %d ms", System.currentTimeMillis() - time);
 
 					if (mappings.getMetadata().getNamespaces().contains(getTargetNamespace())) {
+						this.mappings = mappings;
 						break;
 					}
 


### PR DESCRIPTION
For a while now, quilt meta includes both hashed and intermediary mappings for quilt installations. This was done in an attempt to remove a hackfix required in the quilt installer to deal with wrong mappings. The reasoning for not only specifying intermediary is, that it is not obvious which mappings to include for a given loader version.

Currently the hackfix still exists, as loader isn't capable to deal with wrong mapping files on the class-path. However, this now causes errors in the quilt-installer, since it is trying to download intermediary twice.

Rather than making the hackfix in installer more elaborate to deal with this problem, I created this PR to make loader more tolerant towards additional mapping files on the classpath.