### PR TITLE
Fix #155

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/filesystem/QuiltJoinedFileSystemProvider.java
+++ b/src/main/java/org/quiltmc/loader/impl/filesystem/QuiltJoinedFileSystemProvider.java
@@ -224,12 +224,12 @@ public final class QuiltJoinedFileSystemProvider extends FileSystemProvider {
 				for (int i = 0; i < qmp.fs.getBackingPathCount(); i++) {
 					Path backing = qmp.fs.getBackingPath(i, qmp);
 					backingPaths.add(backing);
-					try {
+					if (Files.isDirectory(backing)) {
 						streams.add(Files.newDirectoryStream(backing, path -> {
 							return filter.accept(toJoinedPath(backing, path));
 						}));
 						anyReal = true;
-					} catch (NotDirectoryException e) {
+					} else {
 						streams.add(null);
 					}
 				}
@@ -259,6 +259,7 @@ public final class QuiltJoinedFileSystemProvider extends FileSystemProvider {
 					closed = true;
 					IOException exception = null;
 					for (DirectoryStream<Path> sub : streams) {
+						if (sub == null) continue;
 						try {
 							sub.close();
 						} catch (IOException e) {
@@ -345,7 +346,7 @@ public final class QuiltJoinedFileSystemProvider extends FileSystemProvider {
 							}
 
 							DirectoryStream<Path> stream = streams.get(index);
-							if (stream  != null) {
+							if (stream != null) {
 								subIterator = stream.iterator();
 							}
 						}

--- a/src/test/java/org/quiltmc/loader/impl/filesystem/QuiltJoinedFileSystemTester.java
+++ b/src/test/java/org/quiltmc/loader/impl/filesystem/QuiltJoinedFileSystemTester.java
@@ -25,74 +25,146 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class QuiltJoinedFileSystemTester {
-
-	@Test
-	public void testMemoryJoined() throws IOException {
-		try (QuiltMemoryFileSystem.ReadWrite rw1 = new QuiltMemoryFileSystem.ReadWrite("rw1", true); //
-			QuiltMemoryFileSystem.ReadWrite rw2 = new QuiltMemoryFileSystem.ReadWrite("rw2", true); //
-			QuiltJoinedFileSystem jfs = new QuiltJoinedFileSystem(
-				"jfs1", Arrays.asList(rw1.root, rw2.root.resolve("sub"))
-			)//
-		) {
-			Assertions.assertFalse(Files.newDirectoryStream(rw1.root).iterator().hasNext());
-			Assertions.assertFalse(Files.newDirectoryStream(rw2.root).iterator().hasNext());
+	@ParameterizedTest
+	@MethodSource("getPaths")
+	public void test(Path rw1, Path rw2) throws IOException {
+		// note, rw2 is mounted at the "sub" subdirectory in the joined filesystem
+		try (QuiltJoinedFileSystem jfs = new QuiltJoinedFileSystem(
+				"jfs", Arrays.asList(rw1, rw2.resolve("sub"))
+		)) {
+			Assertions.assertFalse(Files.newDirectoryStream(rw1).iterator().hasNext());
+			Assertions.assertFalse(Files.newDirectoryStream(rw2).iterator().hasNext());
 			Assertions.assertFalse(Files.newDirectoryStream(jfs.root).iterator().hasNext());
 
-			assertSetsEqual(getChildren(rw1.root));
-			assertSetsEqual(getChildren(rw2.root));
+			assertSetsEqual(getChildren(rw1));
+			assertSetsEqual(getChildren(rw2));
 			assertSetsEqual(getChildren(jfs.root));
 
-			try (BufferedWriter bw = Files.newBufferedWriter(rw1.getPath("greeting.txt"))) {
-				bw.write("hello");
-			}
+			createTestFile(rw1, "greeting.txt");
 
-			Assertions.assertTrue(Files.newDirectoryStream(rw1.root).iterator().hasNext());
-			Assertions.assertFalse(Files.newDirectoryStream(rw2.root).iterator().hasNext());
+			Assertions.assertTrue(Files.newDirectoryStream(rw1).iterator().hasNext());
+			Assertions.assertFalse(Files.newDirectoryStream(rw2).iterator().hasNext());
 			Assertions.assertTrue(Files.newDirectoryStream(jfs.root).iterator().hasNext());
 
-			assertSetsEqual(getChildren(rw1.root), rw1.root.resolve("greeting.txt"));
-			assertSetsEqual(getChildren(rw2.root));
+			assertSetsEqual(getChildren(rw1), rw1.resolve("greeting.txt"));
+			assertSetsEqual(getChildren(rw2));
 			assertSetsEqual(getChildren(jfs.root), jfs.root.resolve("greeting.txt"));
 
-			try (BufferedWriter bw = Files.newBufferedWriter(rw2.getPath("greetings2.txt"))) {
-				bw.write("hello");
-			}
+			createTestFile(rw2, "greetings2.txt");
 
-			Assertions.assertTrue(Files.newDirectoryStream(rw1.root).iterator().hasNext());
-			Assertions.assertTrue(Files.newDirectoryStream(rw2.root).iterator().hasNext());
+			Assertions.assertTrue(Files.newDirectoryStream(rw1).iterator().hasNext());
+			Assertions.assertTrue(Files.newDirectoryStream(rw2).iterator().hasNext());
 			Assertions.assertTrue(Files.newDirectoryStream(jfs.root).iterator().hasNext());
 
-			assertSetsEqual(getChildren(rw1.root), rw1.root.resolve("greeting.txt"));
-			assertSetsEqual(getChildren(rw2.root), rw2.root.resolve("greetings2.txt"));
+			assertSetsEqual(getChildren(rw1), rw1.resolve("greeting.txt"));
+			assertSetsEqual(getChildren(rw2), rw2.resolve("greetings2.txt"));
 			assertSetsEqual(getChildren(jfs.root), jfs.root.resolve("greeting.txt"));
 
-			Path greetings3path = rw2.getPath("sub", "greetings3.txt");
-			Files.createDirectory(greetings3path.getParent());
-			try (BufferedWriter bw = Files.newBufferedWriter(greetings3path)) {
-				bw.write("hello");
-			}
+			Files.createDirectory(rw2.resolve("sub"));
+			createTestFile(rw2, "sub/greetings3.txt");
 
-			Assertions.assertTrue(Files.newDirectoryStream(rw1.root).iterator().hasNext());
-			Assertions.assertTrue(Files.newDirectoryStream(rw2.root).iterator().hasNext());
+			Assertions.assertTrue(Files.newDirectoryStream(rw1).iterator().hasNext());
+			Assertions.assertTrue(Files.newDirectoryStream(rw2).iterator().hasNext());
 			Assertions.assertTrue(Files.newDirectoryStream(jfs.root).iterator().hasNext());
 
-			assertSetsEqual(getChildren(rw1.root), rw1.root.resolve("greeting.txt"));
-			assertSetsEqual(getChildren(rw2.root), rw2.root.resolve("greetings2.txt"), rw2.root.resolve("sub"));
+			assertSetsEqual(getChildren(rw1), rw1.resolve("greeting.txt"));
+			assertSetsEqual(getChildren(rw2), rw2.resolve("greetings2.txt"), rw2.resolve("sub"));
 			assertSetsEqual(
-				getChildren(jfs.root), jfs.root.resolve("greeting.txt"), jfs.root.resolve("greetings3.txt")
+					getChildren(jfs.root), jfs.root.resolve("greeting.txt"), jfs.root.resolve("greetings3.txt")
 			);
 		}
+	}
+
+	@ParameterizedTest
+	@MethodSource("getPaths")
+	public void testDirectoryStream(Path rw1, Path rw2) throws IOException {
+		try (QuiltJoinedFileSystem jfs = new QuiltJoinedFileSystem(
+				"jfs", Arrays.asList(rw1, rw2)
+		)) {
+			createTestFile(rw1, "a.txt");
+			createTestFile(rw2, "b.txt");
+
+			DirectoryStream<Path> stream = Files.newDirectoryStream(jfs.root);
+			Assertions.assertEquals(toSet(stream).size(), 2);
+			stream.close();
+		}
+	}
+
+	/**
+	 * Tests directory streams in an environment where the filesystems have different layouts.
+	 * For example, the folder you're streaming can exist in one filesystem but not another.
+	 */
+	@ParameterizedTest
+	@MethodSource("getPaths")
+	public void testMismatchedDirectoryStream(Path rw1, Path rw2) throws IOException {
+		try (QuiltJoinedFileSystem jfs = new QuiltJoinedFileSystem(
+				"jfs", Arrays.asList(rw1, rw2)
+		)) {
+			// Create a directory in rw2 but not in rw1 and iterate it via the joined filesystem
+			Files.createDirectory(rw2.resolve("streamTest"));
+			createTestFile(rw2, "streamTest/a.txt");
+
+			assertEqual(
+					Files.newDirectoryStream(jfs.root.resolve("streamTest")),
+					jfs.root.resolve("streamTest/a.txt"));
+
+			// Create a file in rw1 with the same name as the directory in rw2 and assert that this is ignored
+			createTestFile(rw1, "streamTest");
+
+			assertEqual(
+					Files.newDirectoryStream(jfs.root.resolve("streamTest")),
+					jfs.root.resolve("streamTest/a.txt"));
+
+			// Explicitly test the closing of directory streams
+			Files.newDirectoryStream(jfs.root.resolve("streamTest")).close();
+		}
+	}
+
+	/**
+	 * @return sets of two paths for testing joined filesystems
+	 */
+	public static Stream<Arguments> getPaths() throws IOException{
+		QuiltMemoryFileSystem.ReadWrite memoryFs1 = new QuiltMemoryFileSystem.ReadWrite("mem1", true);
+		QuiltMemoryFileSystem.ReadWrite memoryFs2 = new QuiltMemoryFileSystem.ReadWrite("mem2", true);
+
+		Path tempFs1 = Files.createTempDirectory("temp1");
+		Path tempFs2 = Files.createTempDirectory("temp2");
+
+		return Stream.of(
+				Arguments.of(memoryFs1.root, memoryFs2.root),
+				Arguments.of(tempFs1, tempFs2)
+		);
 	}
 
 	private static <T> void assertSetsEqual(Set<T> actual, T... expected) {
 		Set<T> expectedSet = new HashSet<>();
 		Collections.addAll(expectedSet, expected);
 		Assertions.assertEquals(expectedSet, actual);
+	}
+
+	private static <T> void assertEqual(DirectoryStream<T> actual, T... expected) throws IOException {
+		assertSetsEqual(toSet(actual), expected);
+	}
+
+	private static <T> Set<T> toSet(DirectoryStream<T> stream) throws IOException {
+		Set<T> set = new HashSet<>();
+		stream.forEach(set::add);
+		stream.close();
+		return set;
+	}
+
+	private static void createTestFile(Path base, String name) throws IOException {
+		try (BufferedWriter bw = Files.newBufferedWriter(base.resolve(name))) {
+			bw.write("this is a test file");
+		}
 	}
 
 	private static Set<Path> getChildren(Path root) throws IOException {


### PR DESCRIPTION
I went on a bit of a tangent with the testcase. At first I wrote the extra testcases. What I didn't realise at first that Quilt's memory fs *doesn't* throw `NoSuchFileException`, but the `UnixFileSystemProvider` *does* (and it seems like other platforms might too). So then I had to rewrite it again to include those in the tests.

This fixes the gametest issues in quilted fapi