### PR TITLE
Remove semver warnings

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/fabric/metadata/V0ModMetadataParser.java
+++ b/src/main/java/org/quiltmc/loader/impl/fabric/metadata/V0ModMetadataParser.java
@@ -97,11 +97,6 @@ final class V0ModMetadataParser {
 
 				try {
 					version = Version.parse(rawVersion);
-					if (!(version instanceof SemanticVersion)) {
-						warnings.add(new ParseWarning(reader.locationString(), "version", "Version " + version + " does not respect SemVer -- comparison support is limited."));
-					} else if (((SemanticVersion) version).getVersionComponentCount() >= 4) {
-						warnings.add(new ParseWarning(reader.locationString(), "version", "Version " + version + " has more than 3 version components, which may not be fully supported."));
-					}
 				} catch (VersionParsingException e) {
 					throw new ParseMetadataException(String.format("Failed to parse version: %s", rawVersion), e);
 				}

--- a/src/main/java/org/quiltmc/loader/impl/fabric/metadata/V1ModMetadataParser.java
+++ b/src/main/java/org/quiltmc/loader/impl/fabric/metadata/V1ModMetadataParser.java
@@ -120,11 +120,6 @@ final class V1ModMetadataParser {
 
 				try {
 					version = Version.parse(reader.nextString());
-					if (!(version instanceof SemanticVersion)) {
-						warnings.add(new ParseWarning(reader.locationString(), "version", "Version " + version + " does not respect SemVer -- comparison support is limited."));
-					} else if (((SemanticVersion) version).getVersionComponentCount() >= 4) {
-						warnings.add(new ParseWarning(reader.locationString(), "version", "Version " + version + " has more than 3 version components, which may not be fully supported."));
-					}
 				} catch (VersionParsingException e) {
 					throw new ParseMetadataException("Failed to parse version", e);
 				}


### PR DESCRIPTION
With the advent of 4e4951221eaaceb1962eaa4297921e7a68326ffd (as discussed in #137) these warnings are now entirely pointless spam left over from FLoader. As QLoader now has a fully featured generic version comparator (and the Fabric Version API is just a facade for Quilt's), printing this because someone had the audacity to install Create or one of dozens of other mods that don't strictly follow semver is pointless and annoying.