### PR TITLE
Fix dependency override removal warning logic being inverted

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/StandardQuiltPlugin.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/StandardQuiltPlugin.java
@@ -31,11 +31,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import org.omg.PortableServer.ID_ASSIGNMENT_POLICY_ID;
 import org.quiltmc.json5.exception.ParseException;
 import org.quiltmc.loader.api.LoaderValue;
 import org.quiltmc.loader.api.ModDependency;
-import org.quiltmc.loader.api.ModDependency.All;
 import org.quiltmc.loader.api.QuiltLoader;
 import org.quiltmc.loader.api.Version;
 import org.quiltmc.loader.api.plugin.ModLocation;
@@ -342,17 +340,18 @@ public class StandardQuiltPlugin extends BuiltinQuiltPlugin {
 
 	private static boolean remove(Collection<ModDependency> in, ModDependency removal, String name) {
 		if (in.remove(removal)) {
-			warn("Failed to find the ModDependency 'from' to " + name + "!");
-			logModDep("", "", removal);
-			warn("Comparison:");
-			if (in.isEmpty()) {
-				warn("  (None left)");
-			}
-			int index = 0;
-			for (ModDependency with : in) {
-				logCompare(" ", "[" + index++ + "]: ", removal, with);
-			}
 			return true;
+		}
+
+		warn("Failed to find the ModDependency 'from' to " + name + "!");
+		logModDep("", "", removal);
+		warn("Comparison:");
+		if (in.isEmpty()) {
+			warn("  (None left)");
+		}
+		int index = 0;
+		for (ModDependency with : in) {
+			logCompare(" ", "[" + index++ + "]: ", removal, with);
 		}
 		return false;
 	}


### PR DESCRIPTION
Inverts the logic for when a dependency override removal logs a warning, as it currently logs when it did find a dependency to remove, rather than when it did not. I moved the warning code out of the block so this is easier to read, overall.

I've also removed two unused imports as my editor was screaming at me for being unable to find the first one, and it doesn't seem like it was added intentionally.