### PR TITLE
Fix Fabric Loader Api getting Quilt Metadata

### DIFF
--- a/src/fabric/impl/java/net/fabricmc/loader/impl/ModContainerImpl.java
+++ b/src/fabric/impl/java/net/fabricmc/loader/impl/ModContainerImpl.java
@@ -51,7 +51,7 @@ public final class ModContainerImpl extends net.fabricmc.loader.ModContainer {
 
 	@Override
 	public LoaderModMetadata getInfo() {
-		return ((ConvertibleModMetadata) quilt.metadata()).asFabricModMetadata(quilt);
+		return ((ConvertibleModMetadata) quilt.metadata()).asFabricModMetadata(quilt).asQuiltModMetadata().asFabricModMetadata();
 	}
 
 	@Override


### PR DESCRIPTION
This solves some fabric mods try to get authors and returns empty.