### PR TITLE
Fix crash from getting super of java/lang/Object

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/util/mappings/MixinIntermediaryDevRemapper.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/mappings/MixinIntermediaryDevRemapper.java
@@ -142,6 +142,11 @@ public class MixinIntermediaryDevRemapper extends MixinRemapper {
 			}
 		}
 
+		// Realistically, this can't be remapped.
+		if (owner.startsWith("java/")) {
+			return name;
+		}
+
 		ClassInfo classInfo = ClassInfo.forName(owner);
 
 		if (classInfo == null) { // unknown class?

--- a/src/main/java/org/quiltmc/loader/impl/util/mappings/MixinIntermediaryDevRemapper.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/mappings/MixinIntermediaryDevRemapper.java
@@ -105,6 +105,11 @@ public class MixinIntermediaryDevRemapper extends MixinRemapper {
 
 	@Override
 	public String mapMethodName(String owner, String name, String desc) {
+		// Realistically, this can't be remapped.
+		if (owner != null && owner.startsWith("java/")) {
+			return name;
+		}
+
 		// handle unambiguous values early
 		if (owner == null || allPossibleClassNames.contains(owner)) {
 			String newName;
@@ -140,11 +145,6 @@ public class MixinIntermediaryDevRemapper extends MixinRemapper {
 					return name;
 				}
 			}
-		}
-
-		// Realistically, this can't be remapped.
-		if (owner.startsWith("java/")) {
-			return name;
 		}
 
 		ClassInfo classInfo = ClassInfo.forName(owner);


### PR DESCRIPTION
This is a blanket ban of `java/`, given that it's normally not expected to be remapped anyways.