### PR TITLE
Fix crash from getting super of java/lang/Object

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/util/mappings/MixinIntermediaryDevRemapper.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/mappings/MixinIntermediaryDevRemapper.java
@@ -102,6 +102,11 @@ public class MixinIntermediaryDevRemapper extends MixinRemapper {
 
 	@Override
 	public String mapMethodName(String owner, String name, String desc) {
+		// Realistically, this can't be remapped.
+		if (owner != null && owner.startsWith("java/")) {
+			return name;
+		}
+
 		// handle unambiguous values early
 		if (owner == null || allPossibleClassNames.contains(owner)) {
 			String newName;


### PR DESCRIPTION
This is a blanket ban of `java/`, given that it's normally not expected to be remapped anyways.

#206 but for the release branch. This should aid in bringing parity to Fabric 0.14.12 for 0.17.9's release, primarily for development.