### PR TITLE
Add a patch system to patch the reflections library to be able to load from quilt file systems

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -87,6 +87,7 @@ import org.quiltmc.loader.impl.launch.common.QuiltMixinBootstrap;
 import org.quiltmc.loader.impl.metadata.FabricLoaderModMetadata;
 import org.quiltmc.loader.impl.metadata.qmj.AdapterLoadableClassEntry;
 import org.quiltmc.loader.impl.metadata.qmj.InternalModMetadata;
+import org.quiltmc.loader.impl.patch.PatchLoader;
 import org.quiltmc.loader.impl.plugin.QuiltPluginErrorImpl;
 import org.quiltmc.loader.impl.plugin.QuiltPluginManagerImpl;
 import org.quiltmc.loader.impl.plugin.fabric.FabricModOption;
@@ -932,6 +933,7 @@ public final class QuiltLoaderImpl {
 		}
 
 		postprocessModMetadata();
+		PatchLoader.load();
 		setupLanguageAdapters();
 		setupMods();
 	}

--- a/src/main/java/org/quiltmc/loader/impl/launch/knot/KnotClassDelegate.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/knot/KnotClassDelegate.java
@@ -28,6 +28,7 @@ import org.quiltmc.loader.impl.QuiltLoaderImpl;
 import org.quiltmc.loader.impl.game.GameProvider;
 import org.quiltmc.loader.impl.launch.common.QuiltCodeSource;
 import org.quiltmc.loader.impl.launch.common.QuiltLauncherBase;
+import org.quiltmc.loader.impl.patch.PatchLoader;
 import org.quiltmc.loader.impl.transformer.PackageEnvironmentStrippingData;
 import org.quiltmc.loader.impl.transformer.QuiltTransformer;
 import org.quiltmc.loader.impl.util.FileSystemUtil;
@@ -476,6 +477,10 @@ class KnotClassDelegate {
 
 		if (!transformFinishedLoading && LOG_EARLY_CLASS_LOADS) {
 			Log.info(LogCategory.GENERAL, "Loading " + name + " early", new Throwable());
+		}
+
+		if (name.startsWith("org.quiltmc.loader.impl.patch.")) {
+			return PatchLoader.getNewPatchedClass(name);
 		}
 
 		if (!transformInitialized || !canTransformClass(name)) {

--- a/src/main/java/org/quiltmc/loader/impl/patch/PatchLoader.java
+++ b/src/main/java/org/quiltmc/loader/impl/patch/PatchLoader.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.loader.impl.patch;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.quiltmc.loader.impl.patch.reflections.ReflectionsClassPatcher;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
+import org.quiltmc.loader.impl.util.log.Log;
+import org.quiltmc.loader.impl.util.log.LogCategory;
+
+@QuiltLoaderInternal(QuiltLoaderInternalType.NEW_INTERNAL)
+public abstract class PatchLoader {
+	private static final Map<String, byte[]> patchedClasses = new HashMap<>();
+
+	public static void load() {
+		ReflectionsClassPatcher.load(patchedClasses);
+	}
+
+	public static byte[] getNewPatchedClass(String name) {
+		byte[] patched = patchedClasses.get(name);
+		if (patched == null) {
+			Log.warn(LogCategory.GENERAL, "Unknown patch class " + name + ", we only know of " + patchedClasses.keySet());
+		}
+		return patched;
+	}
+}

--- a/src/main/java/org/quiltmc/loader/impl/patch/reflections/ReflectionsClassPatcher.java
+++ b/src/main/java/org/quiltmc/loader/impl/patch/reflections/ReflectionsClassPatcher.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.loader.impl.patch.reflections;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.quiltmc.loader.api.QuiltLoader;
+import org.quiltmc.loader.impl.QuiltLoaderImpl;
+import org.quiltmc.loader.impl.launch.common.QuiltLauncherBase;
+import org.quiltmc.loader.impl.patch.PatchLoader;
+import org.quiltmc.loader.impl.util.FileUtil;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
+import org.quiltmc.loader.impl.util.log.Log;
+import org.quiltmc.loader.impl.util.log.LogCategory;
+
+@QuiltLoaderInternal(QuiltLoaderInternalType.NEW_INTERNAL)
+public class ReflectionsClassPatcher extends PatchLoader {
+
+	static final String INPUT_CLASS = "/org/quiltmc/loader/impl/patch/reflections/";
+	static final String TARGET_PACKAGE = "org.quiltmc.loader.impl.patch.reflections.";
+
+	public static void load(Map<String, byte[]> patchedClasses) {
+		if (!QuiltLoader.isModLoaded("org_reflections_reflections")) {
+			return;
+		}
+
+		String urlType = TARGET_PACKAGE + "ReflectionsPathUrlType";
+		try {
+			patchedClasses.put(urlType, patchUrlType());
+			patchedClasses.put(TARGET_PACKAGE + "ReflectionsPathDir", patchDir());
+			patchedClasses.put(TARGET_PACKAGE + "ReflectionsPathFile", patchFile());
+		} catch (IOException e) {
+			throw new Error("Failed to patch a reflections class!", e);
+		}
+
+		try {
+			Class.forName(urlType, true, QuiltLauncherBase.getLauncher().getTargetClassLoader());
+		} catch (ClassNotFoundException e) {
+			throw new Error(e);
+		}
+
+		Log.info(LogCategory.GENERAL, "Successfully patched reflections to be able to handle quilt file systems.");
+	}
+
+	private static byte[] patchUrlType() throws IOException {
+		byte[] input = FileUtil.readAllBytes(
+			ReflectionsClassPatcher.class.getResourceAsStream(INPUT_CLASS + "ReflectionsPathUrlType.class")
+		);
+		ClassReader reader = new ClassReader(input);
+		ClassWriter writer = new ClassWriter(reader, 0);
+		reader.accept(new ClassVisitor(QuiltLoaderImpl.ASM_VERSION, writer) {
+			String owner;
+
+			@Override
+			public void visit(int version, int access, String name, String signature, String superName,
+				String[] interfaces) {
+				super.visit(
+					version, Opcodes.ACC_PUBLIC | access, owner = name, signature, superName, new String[] {
+						"org/reflections/vfs/Vfs$UrlType" }
+				);
+			}
+
+			@Override
+			public MethodVisitor visitMethod(int access, String name, String descriptor, String signature,
+				String[] exceptions) {
+				if (name.equals("createDir")) {
+					String dirType = "org/reflections/vfs/Vfs$Dir";
+					MethodVisitor delegate = super.visitMethod(
+						access, name, "(Ljava/net/URL;)L" + dirType + ";", null, exceptions
+					);
+					delegate.visitMaxs(2, 2);
+					delegate.visitCode();
+					delegate.visitVarInsn(Opcodes.ALOAD, 0);
+					delegate.visitVarInsn(Opcodes.ALOAD, 1);
+					delegate.visitMethodInsn(Opcodes.INVOKEVIRTUAL, owner, name, descriptor, false);
+					delegate.visitTypeInsn(Opcodes.CHECKCAST, dirType);
+					delegate.visitInsn(Opcodes.ARETURN);
+					delegate.visitEnd();
+				}
+				return super.visitMethod(access, name, descriptor, signature, exceptions);
+			}
+		}, 0);
+		return writer.toByteArray();
+	}
+
+	private static byte[] patchDir() throws IOException {
+		byte[] input = FileUtil.readAllBytes(
+			ReflectionsClassPatcher.class.getResourceAsStream(INPUT_CLASS + "ReflectionsPathDir.class")
+		);
+		ClassReader reader = new ClassReader(input);
+		ClassWriter writer = new ClassWriter(reader, 0);
+		reader.accept(new ClassVisitor(QuiltLoaderImpl.ASM_VERSION, writer) {
+			@Override
+			public void visit(int version, int access, String name, String signature, String superName,
+				String[] interfaces) {
+				super.visit(
+					version, Opcodes.ACC_PUBLIC | access, name, signature, superName, new String[] {
+						"org/reflections/vfs/Vfs$Dir" }
+				);
+			}
+		}, 0);
+		return writer.toByteArray();
+	}
+
+	private static byte[] patchFile() throws IOException {
+		byte[] input = FileUtil.readAllBytes(
+			ReflectionsClassPatcher.class.getResourceAsStream(INPUT_CLASS + "ReflectionsPathFile.class")
+		);
+		ClassReader reader = new ClassReader(input);
+		ClassWriter writer = new ClassWriter(reader, 0);
+		reader.accept(new ClassVisitor(QuiltLoaderImpl.ASM_VERSION, writer) {
+			@Override
+			public void visit(int version, int access, String name, String signature, String superName,
+				String[] interfaces) {
+				super.visit(
+					version, Opcodes.ACC_PUBLIC | access, name, signature, superName, new String[] {
+						"org/reflections/vfs/Vfs$File" }
+				);
+			}
+		}, 0);
+		return writer.toByteArray();
+	}
+}

--- a/src/main/java/org/quiltmc/loader/impl/patch/reflections/ReflectionsPathDir.java
+++ b/src/main/java/org/quiltmc/loader/impl/patch/reflections/ReflectionsPathDir.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.loader.impl.patch.reflections;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.quiltmc.loader.api.FasterFiles;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
+
+/** Patch class that is transformed by {@link ReflectionsClassPatcher} to implement "org.reflections.vfs.Vfs.Dir"*/
+@QuiltLoaderInternal(QuiltLoaderInternalType.NEW_INTERNAL)
+class ReflectionsPathDir {
+    final Path path;
+
+    public ReflectionsPathDir(Path path) {
+        this.path = path;
+    }
+
+    public String getPath() {
+        return path.toString().replace(path.getFileSystem().getSeparator(), "/");
+    }
+
+    public Iterable<Object> getFiles() {
+        if (!FasterFiles.isDirectory(path)) {
+            return Collections.emptyList();
+        }
+        return () -> {
+            try {
+                return Files.walk(path)
+                        .filter(Files::isRegularFile)
+                        .map(p -> (Object) new ReflectionsPathFile(ReflectionsPathDir.this, p))
+                        .iterator();
+            } catch (IOException e) {
+                throw new RuntimeException("could not get files for " + path, e);
+            }
+        };
+    }
+}

--- a/src/main/java/org/quiltmc/loader/impl/patch/reflections/ReflectionsPathFile.java
+++ b/src/main/java/org/quiltmc/loader/impl/patch/reflections/ReflectionsPathFile.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.loader.impl.patch.reflections;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
+
+/** Patch class that is transformed by {@link ReflectionsClassPatcher} to implement "org.reflections.vfs.Vfs.File" */
+@QuiltLoaderInternal(QuiltLoaderInternalType.NEW_INTERNAL)
+class ReflectionsPathFile {
+
+    private final ReflectionsPathDir root;
+    private final Path path;
+
+    public ReflectionsPathFile(ReflectionsPathDir root, Path path) {
+        this.root = root;
+        this.path = path;
+    }
+
+    public String getName() {
+        return path.getFileName().toString();
+    }
+
+    public String getRelativePath() {
+        return root.path.relativize(path).toString().replace(path.getFileSystem().getSeparator(), "/");
+    }
+
+    public InputStream openInputStream() throws IOException {
+        return Files.newInputStream(path);
+    }
+
+    @Override
+	public String toString() {
+        return path.toString();
+    }
+}

--- a/src/main/java/org/quiltmc/loader/impl/patch/reflections/ReflectionsPathUrlType.java
+++ b/src/main/java/org/quiltmc/loader/impl/patch/reflections/ReflectionsPathUrlType.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.loader.impl.patch.reflections;
+
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.quiltmc.loader.api.FasterFileSystem;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
+
+/** Patch class that is transformed by {@link ReflectionsClassPatcher} to implement "org.reflections.vfs.Vfs.UrlType" */
+@QuiltLoaderInternal(QuiltLoaderInternalType.NEW_INTERNAL)
+class ReflectionsPathUrlType {
+
+	static {
+		try {
+			Class<?> cls = Class.forName("org.reflections.vfs.Vfs");
+			Field field = cls.getDeclaredField("defaultUrlTypes");
+			field.setAccessible(true);
+			List<Object> list = (List<Object>) field.get(null);
+			list.add(new ReflectionsPathUrlType());
+		} catch (ReflectiveOperationException e) {
+			throw new RuntimeException("Failed to inject into reflections!", e);
+		}
+	}
+
+	public boolean matches(URL url) throws Exception {
+		// Basically only handle quilt file systems
+		Path path = Paths.get(url.toURI());
+		return path.getFileSystem() instanceof FasterFileSystem;
+	}
+
+	public ReflectionsPathDir createDir(URL url) throws Exception {
+		return new ReflectionsPathDir(Paths.get(url.toURI()));
+	}
+}


### PR DESCRIPTION
Fix for #179.

It's not very pretty, and should probably be PR'd upstream to https://github.com/ronmamo/reflections - although we'd need to tweak `ReflectionsPathUrlType.matches` to check for filesystems which aren't already included, as this relies on `Path.getFileSystem() instanceof org.quiltmc.loader.api.FasterFileSystem`. (PRing upstream *won't* fix older versions of those mods however, so this is technically a better fix for our purposes).

This should also allow us to stop copying YUNGs mods too, as AFAIK the only reason we copy those out is due to reflections.