### PR TITLE
Fix ClassNotFoundException involving AppletMain

### DIFF
--- a/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/patch/EntrypointPatch.java
+++ b/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/patch/EntrypointPatch.java
@@ -444,7 +444,7 @@ public class EntrypointPatch extends GamePatch {
 					it.add(new LdcInsnNode("."));
 					it.add(new MethodInsnNode(Opcodes.INVOKESPECIAL, "java/io/File", "<init>", "(Ljava/lang/String;)V", false)); */
 				it.add(new InsnNode(Opcodes.ACONST_NULL));
-				it.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/fabricmc/loader/impl/game/minecraft/applet/AppletMain", "hookGameDir", "(Ljava/io/File;)Ljava/io/File;", false));
+				it.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "org/quiltmc/loader/impl/game/minecraft/applet/AppletMain", "hookGameDir", "(Ljava/io/File;)Ljava/io/File;", false));
 				it.add(new VarInsnNode(Opcodes.ALOAD, 0));
 				finishEntrypoint(type, it);
 			} else {
@@ -452,7 +452,7 @@ public class EntrypointPatch extends GamePatch {
 				ListIterator<AbstractInsnNode> it = gameConstructor.instructions.iterator();
 				moveAfter(it, Opcodes.INVOKESPECIAL); /* Object.init */
 				it.add(new FieldInsnNode(Opcodes.GETSTATIC, gameClass.name, runDirectory.name, runDirectory.desc));
-				it.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/fabricmc/loader/impl/game/minecraft/applet/AppletMain", "hookGameDir", "(Ljava/io/File;)Ljava/io/File;", false));
+				it.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "org/quiltmc/loader/impl/game/minecraft/applet/AppletMain", "hookGameDir", "(Ljava/io/File;)Ljava/io/File;", false));
 				it.add(new FieldInsnNode(Opcodes.PUTSTATIC, gameClass.name, runDirectory.name, runDirectory.desc));
 
 				it = gameMethod.instructions.iterator();


### PR DESCRIPTION
This fixes a bug in which `EntrypointPatch.process()` was pointing to `net/fabricmc/loader/impl/game/minecraft/applet/AppletMain` instead of `org/quiltmc/loader/impl/game/minecraft/applet/AppletMain`, leading to an exception when trying to run Quilt on 1.5.2