### PR TITLE
Wire up loading plugins, for fun.

### DIFF
--- a/src/main/java/org/quiltmc/loader/api/plugin/ModMetadataExt.java
+++ b/src/main/java/org/quiltmc/loader/api/plugin/ModMetadataExt.java
@@ -54,9 +54,7 @@ public interface ModMetadataExt extends ModMetadata, ModMetadataToBeMovedToPlugi
 	}
 
 	@Nullable
-	default ModPlugin plugin() {
-		return null;
-	}
+	ModPlugin plugin();
 
 	public enum ModLoadType {
 		ALWAYS,

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/FabricModMetadataWrapper.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/FabricModMetadataWrapper.java
@@ -191,6 +191,11 @@ public class FabricModMetadataWrapper implements InternalModMetadata {
 		return ModLoadType.IF_POSSIBLE;
 	}
 
+	@Override
+	public @Nullable ModPlugin plugin() {
+		return null;
+	}
+
 	private static Collection<ModDependency> genDepends(Collection<net.fabricmc.loader.api.metadata.ModDependency> from) {
 		List<ModDependency> out = new ArrayList<>();
 		for (net.fabricmc.loader.api.metadata.ModDependency f : from) {

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/V1ModMetadataImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/V1ModMetadataImpl.java
@@ -18,9 +18,12 @@ package org.quiltmc.loader.impl.metadata.qmj;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.Nullable;
+import org.quiltmc.json5.exception.ParseException;
 import org.quiltmc.loader.api.LoaderValue;
 import org.quiltmc.loader.api.ModContainer;
 import org.quiltmc.loader.api.ModContributor;
@@ -34,6 +37,10 @@ import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
 import net.fabricmc.loader.api.metadata.ModEnvironment;
 
 import net.fabricmc.api.EnvType;
+
+import org.quiltmc.loader.impl.util.SystemProperties;
+import org.quiltmc.loader.impl.util.log.Log;
+import org.quiltmc.loader.impl.util.log.LogCategory;
 
 @QuiltLoaderInternal(QuiltLoaderInternalType.LEGACY_EXPOSED)
 final class V1ModMetadataImpl implements InternalModMetadata {
@@ -56,14 +63,14 @@ final class V1ModMetadataImpl implements InternalModMetadata {
 	private final ModLoadType loadType;
 	private final Collection<ProvidedMod> provides;
 	private final Map<String, Collection<AdapterLoadableClassEntry>> entrypoints;
-	private final Collection<AdapterLoadableClassEntry> plugins;
+//	private final Collection<AdapterLoadableClassEntry> plugins;
 	private final Collection<String> jars;
 	private final Map<String, String> languageAdapters;
 	private final Collection<String> repositories;
 	private final Collection<String> mixins;
 	private final Collection<String> accessWideners;
 	private final ModEnvironment environment;
-
+	private final @Nullable ModPlugin plugin;
 	private QuiltModMetadataWrapperFabric cache2fabricNoContainer;
 	private QuiltModMetadataWrapperFabric cache2fabricWithContainer;
 
@@ -119,7 +126,7 @@ final class V1ModMetadataImpl implements InternalModMetadata {
 		this.loadType = builder.loadType;
 		this.provides = Collections.unmodifiableCollection(builder.provides);
 		this.entrypoints = Collections.unmodifiableMap(builder.entrypoints);
-		this.plugins = Collections.unmodifiableCollection(builder.plugins);
+//		this.plugins = Collections.unmodifiableCollection(builder.plugins);
 		this.jars = Collections.unmodifiableCollection(builder.jars);
 		this.languageAdapters = Collections.unmodifiableMap(builder.languageAdapters);
 		this.repositories = Collections.unmodifiableCollection(builder.repositories);
@@ -128,6 +135,38 @@ final class V1ModMetadataImpl implements InternalModMetadata {
 		this.mixins = Collections.unmodifiableCollection(builder.mixins);
 		this.accessWideners = Collections.unmodifiableCollection(builder.accessWideners);
 		this.environment = builder.env;
+
+		// Experimental
+		ModPlugin plugin;
+		@Nullable JsonLoaderValue e = root.get("experimental_quilt_loader_plugin");
+		if (e == null) {
+			plugin = null;
+		} else {
+			if (!Boolean.getBoolean(SystemProperties.ENABLE_EXPERIMENTAL_LOADING_PLUGINS)) {
+				throw new ParseException("Mod " + asQuiltModMetadata().id() + " provides a loader plugin, which is not yet allowed!");
+			}
+			// humorous error message dirties the log + again makes it clear you shouldn't be doing this
+			Log.error(LogCategory.GENERAL, "MOD " + asQuiltModMetadata().id() + " PROVIDES A PLUGIN!" +
+					"MOD-PROVIDED PLUGINS ARE FOR AMUSEMENT PURPOSES ONLY." +
+					" NO WARRANTY IS PROVIDED, EXPRESS OR IMPLIED. CONTINUE AT YOUR OWN RISK.");
+
+			LoaderValue.LObject obj = e.asObject();
+			String clazz = obj.get("class").asString();
+			List<String> packages = obj.get("packages").asArray().stream().map(LoaderValue::asString).collect(Collectors.toList());
+
+			plugin = new ModPlugin() {
+				@Override
+				public String pluginClass() {
+					return clazz;
+				}
+
+				@Override
+				public Collection<String> packages() {
+					return packages;
+				}
+			};
+		}
+		this.plugin = plugin;
 	}
 
 	@Override
@@ -234,6 +273,11 @@ final class V1ModMetadataImpl implements InternalModMetadata {
 	@Override
 	public ModLoadType loadType() {
 		return loadType;
+	}
+
+	@Override
+	public @Nullable ModPlugin plugin() {
+		return this.plugin;
 	}
 
 	@Override

--- a/src/main/java/org/quiltmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/SystemProperties.java
@@ -62,6 +62,7 @@ public final class SystemProperties {
 	public static final String DEBUG_RESOLUTION_TIME_LIMIT = "loader.debug.resolutionTimeLimit";
 	public static final String DEBUG_DUMP_OVERRIDE_PATHS = "loader.debug.dump_override_paths";
 	public static final String ENABLE_EXPERIMENTAL_CHASM = "loader.experimental.enable_chasm";
+	public static final String ENABLE_EXPERIMENTAL_LOADING_PLUGINS = "loader.experimental.allow_loading_plugins";
 	public static final String JAR_COPIED_MODS = "loader.workaround.jar_copied_mods";
 	public static final String DISABLE_STRICT_PARSING = "loader.workaround.disable_strict_parsing";
 	public static final String LOG_EARLY_CLASS_LOADS = "loader.debug.log_early_class_loads";


### PR DESCRIPTION
I'd like to start messing with loader plugins external to Quilt Loader, both for my own amusement and to figure out what kinds of things we might want, find limitations of the current approach, etc.

This PR provides an undocumented way to add a loader plugin from a mod, locked behind a system property. If the system property isn't set, an intentionally vague error message is given. This is intended to prevent people from shipping their own loader plugins just yet (though I know it will happen anyway)