### PR TITLE
Ignore duplicate mods of the same version in development environments.

### DIFF
--- a/minecraft/minecraft-test/build.gradle
+++ b/minecraft/minecraft-test/build.gradle
@@ -15,8 +15,8 @@ repositories {
 
 dependencies {
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
-	minecraft "com.mojang:minecraft:23w07a"
-	mappings "org.quiltmc:quilt-mappings:23w07a+build.2:intermediary-v2"
+	minecraft "com.mojang:minecraft:1.19.4"
+	mappings "org.quiltmc:quilt-mappings:1.19.4+build.5:intermediary-v2"
 
 
 	implementation project(":minecraft")

--- a/src/main/java/org/quiltmc/loader/impl/plugin/QuiltPluginManagerImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/QuiltPluginManagerImpl.java
@@ -1927,8 +1927,9 @@ public class QuiltPluginManagerImpl implements QuiltPluginManager {
 
 		PotentialModSet set = modIds.computeIfAbsent(id, k -> new PotentialModSet());
 
-		if (set.byVersionSingles.containsKey(version) && QuiltLoader.isDevelopmentEnvironment()) {
-			Log.debug(LogCategory.SOLVING, String.format("Ignoring duplicate mod %s of the same version %s loaded from %s", id, version, from));
+		ModLoadOption current = set.byVersionSingles.get(version);
+		if (current != null && current.isMandatory() && mod.isMandatory() && current.getClass() == mod.getClass() && QuiltLoader.isDevelopmentEnvironment()) {
+			Log.warn(LogCategory.SOLVING, String.format("Ignoring duplicate mod %s of the same version %s loaded from %s", id, version, from));
 			return;
 		}
 

--- a/src/main/java/org/quiltmc/loader/impl/plugin/QuiltPluginManagerImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/QuiltPluginManagerImpl.java
@@ -1326,7 +1326,7 @@ public class QuiltPluginManagerImpl implements QuiltPluginManager {
 	}
 
 	/** Processes {@link TentativeLoadOption}s.
-	 * 
+	 *
 	 * @return True if any tentative options were found, false otherwise. */
 	private boolean processTentatives(ModSolveResult partialResult) {
 
@@ -1921,26 +1921,17 @@ public class QuiltPluginManagerImpl implements QuiltPluginManager {
 	}
 
 	void addSingleModOption(ModLoadOption mod, BasePluginContext provider, boolean only, PluginGuiTreeNode guiNode) {
-
-		PluginGuiTreeNode loadedBy = guiNode.addChild(QuiltLoaderText.translate("gui.text.mod_loaded_by", provider.pluginId()))//
-			.mainIcon(mod.modTypeIcon());
-
-		if (only) {
-			guiNode.subIcon(mod.modTypeIcon());
-			loadedBy.debug();
-		}
-
 		String id = mod.id();
 		Version version = mod.version();
 		Path from = mod.from();
-		modPaths.put(from, mod);
-		modProviders.put(mod, provider.pluginId());
-		modGuiNodes.put(mod, guiNode);
-
-		guiNode.addChild(QuiltLoaderText.translate("gui.text.id", id));
-		guiNode.addChild(QuiltLoaderText.translate("gui.text.version", version.raw()));
 
 		PotentialModSet set = modIds.computeIfAbsent(id, k -> new PotentialModSet());
+
+		if (set.byVersionSingles.containsKey(version) && QuiltLoader.isDevelopmentEnvironment()) {
+			Log.debug(LogCategory.SOLVING, String.format("Ignoring duplicate mod %s of the same version %s loaded from %s", id, version, from));
+			return;
+		}
+
 		List<ModLoadOption> already = set.byVersionAll.computeIfAbsent(version, v -> new ArrayList<>());
 		already.add(mod);
 		set.all.add(mod);
@@ -1956,6 +1947,21 @@ public class QuiltPluginManagerImpl implements QuiltPluginManager {
 		if (!(mod instanceof TentativeLoadOption) && mod.metadata().plugin() != null) {
 			idsWithPlugins.add(id);
 		}
+
+		modPaths.put(from, mod);
+		modProviders.put(mod, provider.pluginId());
+		modGuiNodes.put(mod, guiNode);
+
+		PluginGuiTreeNode loadedBy = guiNode.addChild(QuiltLoaderText.translate("gui.text.mod_loaded_by", provider.pluginId()))//
+						.mainIcon(mod.modTypeIcon());
+
+		if (only) {
+			guiNode.subIcon(mod.modTypeIcon());
+			loadedBy.debug();
+		}
+
+		guiNode.addChild(QuiltLoaderText.translate("gui.text.id", id));
+		guiNode.addChild(QuiltLoaderText.translate("gui.text.version", version.raw()));
 
 		addLoadOption(mod, provider);
 	}


### PR DESCRIPTION
Quilt Loader 0.17 and Fabric Loader does this in all environments, but I don't think we should accept duplicate mods in production.
However, many complicated, multi-mod dev environments (QSL, QFAPI) depend on this behavior. While it is probably possible to fandangle a buildscript which does not put the same mod on the classpath multiple times, this is a much simpler solution that matches generally expected behavior.