### PR TITLE
CRITICAL: Make Minecraft entrypoint patch support FlexVer

### DIFF
--- a/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/patch/EntrypointPatch.java
+++ b/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/patch/EntrypointPatch.java
@@ -571,7 +571,7 @@ public class EntrypointPatch extends GamePatch {
 
 	private Version getGameVersion() {
 		try {
-			return SemanticVersion.parse(gameProvider.getNormalizedGameVersion());
+			return Version.parse(gameProvider.getNormalizedGameVersion());
 		} catch (VersionParsingException e) {
 			throw new RuntimeException(e);
 		}


### PR DESCRIPTION
Makes `EntrypointPatch` in the `minecraft` subdir use `Version.parse` instead of `SemanticVersion.parse`. It turns out Mojang cannot be trusted to use SemVer-compliant versioning, as [Snapshot 23w13a_or_b crashes Quilt immediately](https://mclo.gs/5aMCn9D)! This should just be a one-line fix.