### PR TITLE
Provide Fabric Loader 0.4.19

### DIFF
--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -22,7 +22,7 @@
     "provides": [
       {
         "id": "fabricloader",
-        "version": "0.14.18"
+        "version": "0.14.19"
       }
     ]
   }


### PR DESCRIPTION
Fabric Loader was updated to support 23w13a_or_b, so the version number was bumped (which FAPI depends on)

See https://github.com/FabricMC/fabric-loader/commit/69fefcb72af0598524b1468028b3a93202dc517b