### PR TITLE
Fix addFileToScan only adding files as non-direct

### DIFF
--- a/src/main/java/org/quiltmc/loader/api/plugin/ModLocation.java
+++ b/src/main/java/org/quiltmc/loader/api/plugin/ModLocation.java
@@ -17,6 +17,7 @@
 package org.quiltmc.loader.api.plugin;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.quiltmc.loader.api.plugin.solver.ModLoadOption;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
 
@@ -28,8 +29,8 @@ public interface ModLocation {
 	/** @return True if the mod is directly on the classpath, otherwise false. */
 	boolean onClasspath();
 
-	/** @return True if the mod was scanned as a direct result of
-	 *         {@link QuiltPluginContext#addFolderToScan(java.nio.file.Path)}, rather than being scanned as a sub-mod.
-	 *         This also returns true if {@link #onClasspath()} returns true. */
+	/** @return True if the mod was directly scanned as a file or folder, rather than being scanned as a sub-mod.
+	 *         This also returns true if {@link #onClasspath()} returns true.
+	 *         Influences {@link ModLoadOption#isMandatory()} in the built-in plugins. */
 	boolean isDirect();
 }

--- a/src/main/java/org/quiltmc/loader/api/plugin/QuiltPluginContext.java
+++ b/src/main/java/org/quiltmc/loader/api/plugin/QuiltPluginContext.java
@@ -61,8 +61,9 @@ public interface QuiltPluginContext {
 	 * (This is more flexible than loading files manually, since it allows fabric mods to be jar-in-jar'd in quilt mods,
 	 * or vice versa. Or any mod type of which a loader plugin can load).
 	 * 
-	 * @param guiNode TODO */
-	void addFileToScan(Path file, PluginGuiTreeNode guiNode);
+	 * @param guiNode The GUI node to display the loaded mod details under
+	 * @param direct True if the file is directly loaded rather than being included in another mod (see {@link ModLocation#isDirect()}) */
+	void addFileToScan(Path file, PluginGuiTreeNode guiNode, boolean direct);
 
 	/** Adds an additional folder to scan for mods, which will be treated in the same way as the regular mods folder.
 	 *

--- a/src/main/java/org/quiltmc/loader/impl/discovery/ArgumentModCandidateFinder.java
+++ b/src/main/java/org/quiltmc/loader/impl/discovery/ArgumentModCandidateFinder.java
@@ -121,7 +121,7 @@ public class ArgumentModCandidateFinder {
 				error.appendReportText(" (Inside the file " + source + ")");
 			}
 		} else {
-			ctx.addFileToScan(path, ctx.manager().getRootGuiNode().addChild(QuiltLoaderText.translate("")));
+			ctx.addFileToScan(path, ctx.manager().getRootGuiNode().addChild(QuiltLoaderText.translate("")), true);
 		}
 	}
 }

--- a/src/main/java/org/quiltmc/loader/impl/plugin/BasePluginContext.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/BasePluginContext.java
@@ -67,9 +67,9 @@ abstract class BasePluginContext implements QuiltPluginContext {
 	}
 
 	@Override
-	public void addFileToScan(Path file, PluginGuiTreeNode guiNode) {
+	public void addFileToScan(Path file, PluginGuiTreeNode guiNode, boolean direct) {
 		// TODO: Log / store / do something to store the plugin
-		manager.scanModFile(file, new ModLocationImpl(false, false), guiNode);
+		manager.scanModFile(file, new ModLocationImpl(false, direct), guiNode);
 	}
 
 	@Override

--- a/src/main/java/org/quiltmc/loader/impl/plugin/fabric/StandardFabricPlugin.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/fabric/StandardFabricPlugin.java
@@ -98,7 +98,7 @@ public class StandardFabricPlugin extends BuiltinQuiltPlugin {
 				}
 
 				PluginGuiTreeNode jarNode = guiNode.addChild(QuiltLoaderText.of(jar), SortOrder.ALPHABETICAL_ORDER);
-				context().addFileToScan(inner, jarNode);
+				context().addFileToScan(inner, jarNode, false);
 			}
 
 			boolean mandatory = location.isDirect();

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/StandardQuiltPlugin.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/StandardQuiltPlugin.java
@@ -247,7 +247,7 @@ public class StandardQuiltPlugin extends BuiltinQuiltPlugin {
 				}
 
 				PluginGuiTreeNode jarNode = guiNode.addChild(QuiltLoaderText.of(jar), SortOrder.ALPHABETICAL_ORDER);
-				context().addFileToScan(inner, jarNode);
+				context().addFileToScan(inner, jarNode, false);
 			}
 
 			// a mod needs to be remapped if we are in a development environment, and the mod


### PR DESCRIPTION
Plugins should be required to specify whether files should be direct or not, so sub-mods and top-level mods can be handled properly. (breaking change to the experimental plugin API!)

Most plugins will want to add files as direct anyway; the javadoc even implied that this was the case (matching the mods dir). This also fixes mods added by argument being non-direct (so they wouldn't be loaded unless a dependency was added on them).

Includes fixes to the javadocs of ModLocation.isDirect and QuiltPluginContext.addFileToScan.