### PR TITLE
Cleaner display of mods added from arguments

### DIFF
--- a/src/main/java/org/quiltmc/loader/api/plugin/ModLocation.java
+++ b/src/main/java/org/quiltmc/loader/api/plugin/ModLocation.java
@@ -17,6 +17,7 @@
 package org.quiltmc.loader.api.plugin;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.quiltmc.loader.api.plugin.solver.ModLoadOption;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
 
@@ -28,8 +29,8 @@ public interface ModLocation {
 	/** @return True if the mod is directly on the classpath, otherwise false. */
 	boolean onClasspath();
 
-	/** @return True if the mod was scanned as a direct result of
-	 *         {@link QuiltPluginContext#addFolderToScan(java.nio.file.Path)}, rather than being scanned as a sub-mod.
-	 *         This also returns true if {@link #onClasspath()} returns true. */
+	/** @return True if the mod was directly scanned as a file or folder, rather than being scanned as a sub-mod.
+	 *         This also returns true if {@link #onClasspath()} returns true.
+	 *         Influences {@link ModLoadOption#isMandatory()} in the built-in plugins. */
 	boolean isDirect();
 }

--- a/src/main/java/org/quiltmc/loader/api/plugin/QuiltPluginContext.java
+++ b/src/main/java/org/quiltmc/loader/api/plugin/QuiltPluginContext.java
@@ -61,8 +61,9 @@ public interface QuiltPluginContext {
 	 * (This is more flexible than loading files manually, since it allows fabric mods to be jar-in-jar'd in quilt mods,
 	 * or vice versa. Or any mod type of which a loader plugin can load).
 	 * 
-	 * @param guiNode TODO */
-	void addFileToScan(Path file, PluginGuiTreeNode guiNode);
+	 * @param guiNode The GUI node to display the loaded mod details under
+	 * @param direct True if the file is directly loaded rather than being included in another mod (see {@link ModLocation#isDirect()}) */
+	void addFileToScan(Path file, PluginGuiTreeNode guiNode, boolean direct);
 
 	/** Adds an additional folder to scan for mods, which will be treated in the same way as the regular mods folder.
 	 *

--- a/src/main/java/org/quiltmc/loader/impl/discovery/ArgumentModCandidateFinder.java
+++ b/src/main/java/org/quiltmc/loader/impl/discovery/ArgumentModCandidateFinder.java
@@ -121,7 +121,7 @@ public class ArgumentModCandidateFinder {
 				error.appendReportText(" (Inside the file " + source + ")");
 			}
 		} else {
-			ctx.addFileToScan(path, ctx.manager().getRootGuiNode().addChild(QuiltLoaderText.translate("")));
+			ctx.addFileToScan(path, ctx.manager().getRootGuiNode().addChild(QuiltLoaderText.translate("")), true);
 		}
 	}
 }

--- a/src/main/java/org/quiltmc/loader/impl/discovery/ArgumentModCandidateFinder.java
+++ b/src/main/java/org/quiltmc/loader/impl/discovery/ArgumentModCandidateFinder.java
@@ -28,6 +28,7 @@ import org.quiltmc.loader.api.FasterFiles;
 import org.quiltmc.loader.api.gui.QuiltDisplayedError;
 import org.quiltmc.loader.api.gui.QuiltLoaderText;
 import org.quiltmc.loader.api.plugin.QuiltPluginContext;
+import org.quiltmc.loader.api.plugin.gui.PluginGuiTreeNode;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
 import org.quiltmc.loader.impl.util.log.Log;
@@ -37,6 +38,7 @@ import org.quiltmc.loader.impl.util.log.LogCategory;
 public class ArgumentModCandidateFinder {
 
 	public static void addMods(QuiltPluginContext ctx, String list, String source) {
+		PluginGuiTreeNode argModsNode = ctx.manager().getRootGuiNode().addChild(QuiltLoaderText.translate("gui.text.arg_mods"));
 		for (String pathStr : list.split(File.pathSeparator)) {
 			if (pathStr.isEmpty()) continue;
 
@@ -58,7 +60,7 @@ public class ArgumentModCandidateFinder {
 						line = line.trim();
 						if (line.isEmpty()) continue;
 
-						addMod(ctx, line, source, fileSource);
+						addMod(ctx, line, source, fileSource, argModsNode);
 					}
 				} catch (IOException e) {
 					throw new RuntimeException(
@@ -66,12 +68,12 @@ public class ArgumentModCandidateFinder {
 					);
 				}
 			} else {
-				addMod(ctx, pathStr, source, null);
+				addMod(ctx, pathStr, source, null, argModsNode);
 			}
 		}
 	}
 
-	private static void addMod(QuiltPluginContext ctx, String pathStr, String original, String source) {
+	private static void addMod(QuiltPluginContext ctx, String pathStr, String original, String source, PluginGuiTreeNode argModsNode) {
 
 		final boolean folder = pathStr.endsWith(File.separator + "*") || pathStr.endsWith("/*");
 
@@ -121,7 +123,7 @@ public class ArgumentModCandidateFinder {
 				error.appendReportText(" (Inside the file " + source + ")");
 			}
 		} else {
-			ctx.addFileToScan(path, ctx.manager().getRootGuiNode().addChild(QuiltLoaderText.translate("")), true);
+			ctx.addFileToScan(path, argModsNode.addChild(QuiltLoaderText.of(pathStr)), true);
 		}
 	}
 }

--- a/src/main/java/org/quiltmc/loader/impl/plugin/BasePluginContext.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/BasePluginContext.java
@@ -67,9 +67,9 @@ abstract class BasePluginContext implements QuiltPluginContext {
 	}
 
 	@Override
-	public void addFileToScan(Path file, PluginGuiTreeNode guiNode) {
+	public void addFileToScan(Path file, PluginGuiTreeNode guiNode, boolean direct) {
 		// TODO: Log / store / do something to store the plugin
-		manager.scanModFile(file, new ModLocationImpl(false, false), guiNode);
+		manager.scanModFile(file, new ModLocationImpl(false, direct), guiNode);
 	}
 
 	@Override

--- a/src/main/java/org/quiltmc/loader/impl/plugin/fabric/StandardFabricPlugin.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/fabric/StandardFabricPlugin.java
@@ -98,7 +98,7 @@ public class StandardFabricPlugin extends BuiltinQuiltPlugin {
 				}
 
 				PluginGuiTreeNode jarNode = guiNode.addChild(QuiltLoaderText.of(jar), SortOrder.ALPHABETICAL_ORDER);
-				context().addFileToScan(inner, jarNode);
+				context().addFileToScan(inner, jarNode, false);
 			}
 
 			boolean mandatory = location.isDirect();

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/StandardQuiltPlugin.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/StandardQuiltPlugin.java
@@ -247,7 +247,7 @@ public class StandardQuiltPlugin extends BuiltinQuiltPlugin {
 				}
 
 				PluginGuiTreeNode jarNode = guiNode.addChild(QuiltLoaderText.of(jar), SortOrder.ALPHABETICAL_ORDER);
-				context().addFileToScan(inner, jarNode);
+				context().addFileToScan(inner, jarNode, false);
 			}
 
 			// a mod needs to be remapped if we are in a development environment, and the mod

--- a/src/main/resources/lang/quilt_loader.properties
+++ b/src/main/resources/lang/quilt_loader.properties
@@ -4,6 +4,7 @@
 # Node names
 gui.text.classpath=Classpath
 gui.text.floating_mods_from_plugins=Floating mods from plugins
+gui.text.arg_mods=Loader arguments
 # General text
 gui.text.plugin=plugin: '%s'
 gui.text.loaded_by_plugin=loaded by plugin: %s


### PR DESCRIPTION
Before:
![java_aAWTR1evla](https://user-images.githubusercontent.com/1138417/229385483-ada5c5fd-9d64-4b6a-b8f4-6815b76254a8.png)

After:
![java_M5CHKLo1cZ](https://user-images.githubusercontent.com/1138417/229385486-2bd8fd2f-36ba-4abb-8cec-d6909c948ed9.png)

(builds on https://github.com/QuiltMC/quilt-loader/pull/276, let me know if you want me to rebase this) 