### PR TITLE
 Print a mod "type" (Quilt, Fabric) instead of its loading plugin in mod table

### DIFF
--- a/src/main/java/org/quiltmc/loader/api/plugin/ModContainerExt.java
+++ b/src/main/java/org/quiltmc/loader/api/plugin/ModContainerExt.java
@@ -26,7 +26,15 @@ public interface ModContainerExt extends ModContainer {
 	@Override
 	ModMetadataExt metadata();
 
+	/**
+	 * @return the id of the plugin providing this mod. This method MUST return the actual id of the plugin.
+	 */
 	String pluginId();
+
+	/**
+	 * @return friendly string that describes the "kind" of mod being loaded, like "Sponge", "Quilt", or "Fabric"
+	 */
+	String modKind();
 
 	/** @return True if quilt-loader should add {@link #rootPath()} to it's classpath, false otherwise. */
 	boolean shouldAddToQuiltClasspath();

--- a/src/main/java/org/quiltmc/loader/api/plugin/ModContainerExt.java
+++ b/src/main/java/org/quiltmc/loader/api/plugin/ModContainerExt.java
@@ -32,9 +32,13 @@ public interface ModContainerExt extends ModContainer {
 	String pluginId();
 
 	/**
-	 * @return friendly string that describes the "kind" of mod being loaded, like "Sponge", "Quilt", or "Fabric"
+	 * A user-friendly, unique string that describes the "type" of mod being loaded.
+	 * <p>
+	 * Values returned by Quilt Loader (and therefore shouldn't be used by external plugins!) include "Fabric",
+	 * "Quilt", and "Builtin".
 	 */
-	String modKind();
+
+	String modType();
 
 	/** @return True if quilt-loader should add {@link #rootPath()} to it's classpath, false otherwise. */
 	boolean shouldAddToQuiltClasspath();

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -664,7 +664,7 @@ public final class QuiltLoaderImpl {
 		int maxNameLength = "Mod".length();
 		int maxIdLength = "ID".length();
 		int maxVersionLength = "Version".length();
-		int maxKindLength = "Kind".length();
+		int maxTypeLength = "Kind".length();
 		List<Integer> maxSourcePathLengths = new ArrayList<>();
 		Path absoluteGameDir = gameDir.toAbsolutePath().normalize();
 		Path absoluteModsDir = modsDir.toAbsolutePath().normalize();
@@ -673,7 +673,7 @@ public final class QuiltLoaderImpl {
 			maxNameLength = Math.max(maxNameLength, mod.metadata().name().length());
 			maxIdLength = Math.max(maxIdLength, mod.metadata().id().length());
 			maxVersionLength = Math.max(maxVersionLength, mod.metadata().version().toString().length());
-			maxKindLength = Math.max(maxKindLength, mod.modKind().length());
+			maxTypeLength = Math.max(maxTypeLength, mod.modType().length());
 
 			for (List<Path> paths : mod.getSourcePaths()) {
 				for (int i = 0; i < paths.size(); i++) {
@@ -691,7 +691,7 @@ public final class QuiltLoaderImpl {
 
 		maxIdLength++;
 		maxVersionLength++;
-		maxKindLength++;
+		maxTypeLength++;
 
 		StringBuilder sbTab = new StringBuilder();
 		StringBuilder sbSep = new StringBuilder();
@@ -715,9 +715,9 @@ public final class QuiltLoaderImpl {
 			sbTab.append(" ");
 			sbSep.append("-");
 		}
-		sbTab.append("| Kind ");
+		sbTab.append("| Type ");
 		sbSep.append("|------");
-		for (int i = "Kind".length(); i < maxKindLength; i++) {
+		for (int i = "Type".length(); i < maxTypeLength; i++) {
 			sbTab.append(" ");
 			sbSep.append("-");
 		}
@@ -748,7 +748,7 @@ public final class QuiltLoaderImpl {
 			// - Name
 			// - ID
 			// - version
-			// - plugin kind
+			// - mod type
 			// - source path(s)
 			sbTab.append("| ");
 			String index = Integer.toString(mods.indexOf(mod));
@@ -767,8 +767,8 @@ public final class QuiltLoaderImpl {
 			for (int i = mod.metadata().version().toString().length(); i < maxVersionLength; i++) {
 				sbTab.append(" ");
 			}
-			sbTab.append(" | ").append(mod.modKind());
-			for (int i = mod.modKind().length(); i < maxKindLength; i++) {
+			sbTab.append(" | ").append(mod.modType());
+			for (int i = mod.modType().length(); i < maxTypeLength; i++) {
 				sbTab.append(" ");
 			}
 
@@ -793,7 +793,7 @@ public final class QuiltLoaderImpl {
 						sbTab.append(" ");
 					}
 					sbTab.append(" | ");
-					for (int i = 0; i < maxKindLength; i++) {
+					for (int i = 0; i < maxTypeLength; i++) {
 						sbTab.append(" ");
 					}
 				}
@@ -819,12 +819,12 @@ public final class QuiltLoaderImpl {
 
 		to.accept(sbSep.toString());
 		to.accept("");
-		to.accept("Mod-Table-Version: 2"); // Increment this when ANYTHING is changed in the table, or one of the values below the table changes meaning
+		to.accept("Mod Table Version: 2"); // Increment this when ANYTHING is changed in the table, or one of the values below the table changes meaning
 		HashMap<String, Set<String>> kinds = new HashMap<>();
 		for (ModContainerExt mod : mods) {
-			kinds.computeIfAbsent(mod.pluginId(), k -> new HashSet<>()).add(mod.modKind());
+			kinds.computeIfAbsent(mod.pluginId(), k -> new HashSet<>()).add(mod.modType());
 		}
-		to.accept("Plugin-Kinds: " + kinds);
+		to.accept("Plugin Types: " + kinds);
 	}
 
 	public static String prefixPath(Path gameDir, Path modsDir, Path path) {

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -743,7 +743,7 @@ public final class QuiltLoaderImpl {
 		sbTab.setLength(0);
 		to.accept(sbSep.toString());
 
-		for (ModContainerExt mod : mods.stream().sorted(Comparator.comparing(i -> i.metadata().name())).collect(Collectors.toList())) {
+		for (ModContainerExt mod : mods.stream().sorted(Comparator.comparing(i -> i.metadata().name().toLowerCase())).collect(Collectors.toList())) {
 			// - Index
 			// - Name
 			// - ID

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -694,6 +694,7 @@ public final class QuiltLoaderImpl {
 			}
 		}
 
+		table.appendTable(to);
 
 		HashMap<String, Set<String>> types = new HashMap<>();
 
@@ -701,10 +702,8 @@ public final class QuiltLoaderImpl {
 			types.computeIfAbsent(mod.pluginId(), k -> new HashSet<>()).add(mod.modType());
 		}
 
-		table.addExtraData("Mod Table Version: 2");
-		table.addExtraData("Plugin Types: " + types);
-
-		table.appendTable(to);
+		to.accept("Mod Table Version: 2");
+		to.accept("Plugin Types: " + types);
 	}
 
 	public static String prefixPath(Path gameDir, Path modsDir, Path path) {

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -658,13 +658,13 @@ public final class QuiltLoaderImpl {
 		// - Name
 		// - ID
 		// - version
-		// - loader plugin
+		// - plugin kind
 		// - source path(s)
 
 		int maxNameLength = "Mod".length();
 		int maxIdLength = "ID".length();
 		int maxVersionLength = "Version".length();
-		int maxPluginLength = "Plugin".length();
+		int maxKindLength = "Kind".length();
 		List<Integer> maxSourcePathLengths = new ArrayList<>();
 		Path absoluteGameDir = gameDir.toAbsolutePath().normalize();
 		Path absoluteModsDir = modsDir.toAbsolutePath().normalize();
@@ -673,7 +673,7 @@ public final class QuiltLoaderImpl {
 			maxNameLength = Math.max(maxNameLength, mod.metadata().name().length());
 			maxIdLength = Math.max(maxIdLength, mod.metadata().id().length());
 			maxVersionLength = Math.max(maxVersionLength, mod.metadata().version().toString().length());
-			maxPluginLength = Math.max(maxPluginLength, mod.pluginId().length());
+			maxKindLength = Math.max(maxKindLength, mod.modKind().length());
 
 			for (List<Path> paths : mod.getSourcePaths()) {
 				for (int i = 0; i < paths.size(); i++) {
@@ -691,7 +691,7 @@ public final class QuiltLoaderImpl {
 
 		maxIdLength++;
 		maxVersionLength++;
-		maxPluginLength++;
+		maxKindLength++;
 
 		StringBuilder sbTab = new StringBuilder();
 		StringBuilder sbSep = new StringBuilder();
@@ -715,9 +715,9 @@ public final class QuiltLoaderImpl {
 			sbTab.append(" ");
 			sbSep.append("-");
 		}
-		sbTab.append("| Plugin ");
-		sbSep.append("|--------");
-		for (int i = "Plugin".length(); i < maxPluginLength; i++) {
+		sbTab.append("| Kind ");
+		sbSep.append("|------");
+		for (int i = "Kind".length(); i < maxKindLength; i++) {
 			sbTab.append(" ");
 			sbSep.append("-");
 		}
@@ -748,7 +748,7 @@ public final class QuiltLoaderImpl {
 			// - Name
 			// - ID
 			// - version
-			// - loader plugin
+			// - plugin kind
 			// - source path(s)
 			sbTab.append("| ");
 			String index = Integer.toString(mods.indexOf(mod));
@@ -767,8 +767,8 @@ public final class QuiltLoaderImpl {
 			for (int i = mod.metadata().version().toString().length(); i < maxVersionLength; i++) {
 				sbTab.append(" ");
 			}
-			sbTab.append(" | ").append(mod.pluginId());
-			for (int i = mod.pluginId().length(); i < maxPluginLength; i++) {
+			sbTab.append(" | ").append(mod.modKind());
+			for (int i = mod.modKind().length(); i < maxKindLength; i++) {
 				sbTab.append(" ");
 			}
 
@@ -793,7 +793,7 @@ public final class QuiltLoaderImpl {
 						sbTab.append(" ");
 					}
 					sbTab.append(" | ");
-					for (int i = 0; i < maxPluginLength; i++) {
+					for (int i = 0; i < maxKindLength; i++) {
 						sbTab.append(" ");
 					}
 				}
@@ -818,6 +818,13 @@ public final class QuiltLoaderImpl {
 		}
 
 		to.accept(sbSep.toString());
+		to.accept("");
+		to.accept("Mod-Table-Version: 2"); // Increment this when ANYTHING is changed in the table, or one of the values below the table changes meaning
+		HashMap<String, Set<String>> kinds = new HashMap<>();
+		for (ModContainerExt mod : mods) {
+			kinds.computeIfAbsent(mod.pluginId(), k -> new HashSet<>()).add(mod.modKind());
+		}
+		to.accept("Plugin-Kinds: " + kinds);
 	}
 
 	public static String prefixPath(Path gameDir, Path modsDir, Path path) {

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -694,6 +694,16 @@ public final class QuiltLoaderImpl {
 			}
 		}
 
+
+		HashMap<String, Set<String>> types = new HashMap<>();
+
+		for (ModContainerExt mod : mods) {
+			types.computeIfAbsent(mod.pluginId(), k -> new HashSet<>()).add(mod.modType());
+		}
+
+		table.addExtraData("Mod Table Version: 2");
+		table.addExtraData("Plugin Types: " + types);
+
 		table.appendTable(to);
 	}
 

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/ProvidedModContainer.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/ProvidedModContainer.java
@@ -61,6 +61,11 @@ public class ProvidedModContainer implements ModContainerExt {
 	}
 
 	@Override
+	public String modKind() {
+		return "Provided";
+	}
+
+	@Override
 	public boolean shouldAddToQuiltClasspath() {
 		return false;
 	}

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/ProvidedModContainer.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/ProvidedModContainer.java
@@ -61,7 +61,7 @@ public class ProvidedModContainer implements ModContainerExt {
 	}
 
 	@Override
-	public String modKind() {
+	public String modType() {
 		return "Provided";
 	}
 

--- a/src/main/java/org/quiltmc/loader/impl/plugin/base/InternalModOptionBase.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/base/InternalModOptionBase.java
@@ -43,7 +43,6 @@ public abstract class InternalModOptionBase extends ModLoadOption {
 
 	public InternalModOptionBase(QuiltPluginContext pluginContext, ModMetadataExt meta, Path from,
 		QuiltLoaderIcon fileIcon, Path resourceRoot, boolean mandatory, boolean requiresRemap) {
-
 		this.pluginContext = pluginContext;
 		this.metadata = meta;
 		this.from = from;

--- a/src/main/java/org/quiltmc/loader/impl/plugin/fabric/FabricModContainer.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/fabric/FabricModContainer.java
@@ -37,7 +37,7 @@ public class FabricModContainer extends InternalModContainerBase {
 	}
 
 	@Override
-	public String modKind() {
+	public String modType() {
 		return "Fabric";
 	}
 }

--- a/src/main/java/org/quiltmc/loader/impl/plugin/fabric/FabricModContainer.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/fabric/FabricModContainer.java
@@ -35,4 +35,9 @@ public class FabricModContainer extends InternalModContainerBase {
 	public BasicSourceType getSourceType() {
 		return BasicSourceType.NORMAL_FABRIC;
 	}
+
+	@Override
+	public String modKind() {
+		return "Fabric";
+	}
 }

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/BuiltinModContainer.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/BuiltinModContainer.java
@@ -40,7 +40,7 @@ public class BuiltinModContainer extends InternalModContainerBase {
 	}
 
 	@Override
-	public String modKind() {
+	public String modType() {
 		return "Builtin";
 	}
 

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/BuiltinModContainer.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/BuiltinModContainer.java
@@ -40,6 +40,11 @@ public class BuiltinModContainer extends InternalModContainerBase {
 	}
 
 	@Override
+	public String modKind() {
+		return "Builtin";
+	}
+
+	@Override
 	public boolean shouldAddToQuiltClasspath() {
 		return addToClasspath;
 	}

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/QuiltModContainer.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/QuiltModContainer.java
@@ -32,6 +32,11 @@ public class QuiltModContainer extends InternalModContainerBase {
 	}
 
 	@Override
+	public String modKind() {
+		return "Quilt";
+	}
+
+	@Override
 	public BasicSourceType getSourceType() {
 		return BasicSourceType.NORMAL_QUILT;
 	}

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/QuiltModContainer.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/QuiltModContainer.java
@@ -32,7 +32,7 @@ public class QuiltModContainer extends InternalModContainerBase {
 	}
 
 	@Override
-	public String modKind() {
+	public String modType() {
 		return "Quilt";
 	}
 

--- a/src/main/java/org/quiltmc/loader/impl/util/AsciiTableGenerator.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/AsciiTableGenerator.java
@@ -176,7 +176,6 @@ public class AsciiTableGenerator {
 		}
 
 		dst.accept(sep);
-		dst.accept("");
 	}
 
 	private static int computeAsciiWidth(String text) {

--- a/src/main/java/org/quiltmc/loader/impl/util/AsciiTableGenerator.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/AsciiTableGenerator.java
@@ -26,7 +26,6 @@ import java.util.function.Consumer;
 public class AsciiTableGenerator {
 	private final List<AsciiTableColumn> columns = new ArrayList<>();
 	private final List<AsciiTableRow> rows = new ArrayList<>();
-	private final List<String> extraData = new ArrayList<>();
 
 	public static final class AsciiTableColumn {
 		AsciiTableCell name;
@@ -125,13 +124,6 @@ public class AsciiTableGenerator {
 		return row;
 	}
 
-	/**
-	 * Extra data to be printed below the mod table. Usually in the form of "Some Key: Value", but may be anything.
-	 */
-	public void addExtraData(String string) {
-		extraData.add(string);
-	}
-
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
@@ -185,10 +177,6 @@ public class AsciiTableGenerator {
 
 		dst.accept(sep);
 		dst.accept("");
-
-		for (String extra : extraData) {
-			dst.accept(extra);
-		}
 	}
 
 	private static int computeAsciiWidth(String text) {

--- a/src/main/java/org/quiltmc/loader/impl/util/AsciiTableGenerator.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/AsciiTableGenerator.java
@@ -26,6 +26,7 @@ import java.util.function.Consumer;
 public class AsciiTableGenerator {
 	private final List<AsciiTableColumn> columns = new ArrayList<>();
 	private final List<AsciiTableRow> rows = new ArrayList<>();
+	private final List<String> extraData = new ArrayList<>();
 
 	public static final class AsciiTableColumn {
 		AsciiTableCell name;
@@ -124,6 +125,13 @@ public class AsciiTableGenerator {
 		return row;
 	}
 
+	/**
+	 * Extra data to be printed below the mod table. Usually in the form of "Some Key: Value", but may be anything.
+	 */
+	public void addExtraData(String string) {
+		extraData.add(string);
+	}
+
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
@@ -176,6 +184,11 @@ public class AsciiTableGenerator {
 		}
 
 		dst.accept(sep);
+		dst.accept("");
+
+		for (String extra : extraData) {
+			dst.accept(extra);
+		}
 	}
 
 	private static int computeAsciiWidth(String text) {


### PR DESCRIPTION
Mod types are a lot clearer to a user than plugins. For debugging, a single-line map is printed at the bottom of the mod table which gives mappings from mod id to all of the mod kinds it has provided.

An image is worth several words (outdated screenshot):
![An image of the mod table's appearance after this PR. The old "Plugin" column is replaced by a new "Kind" column](https://user-images.githubusercontent.com/19521552/230241319-cecb9a9f-6422-44d6-9119-3c74ee63f17c.png)

Two other changes were made to the table in this PR:
- The table now ignores case when sorting the table, putting "Minecraft" next to "minecraft_test". This makes the mod table easier to search, since capitalization is unpredictable in mod names.
- The mod table now adds a `Mod Table Version` property at the end, which is incremented any time we make a change to the table or the extra variables at the end. This is intended to give @gdude2002 a little help when parsing logs in Cozy.