### PR TITLE
Add mod vetoes

### DIFF
--- a/minecraft/minecraft-test/src/main/resources/quilt.mod.json
+++ b/minecraft/minecraft-test/src/main/resources/quilt.mod.json
@@ -9,10 +9,14 @@
       "main": [
         "net.fabricmc.minecraft.test.FabricEntrypointTest"
       ]
-    }
+    },
+    "load_type": "always"
   },
   "mixin": [
     "fabricmc.test.mixins.client.json"
   ],
+  "minecraft": {
+    "environment": "client"
+  },
   "experimental_chasm_transformers_disabled": "chasm_transformers"
 }

--- a/src/main/java/org/quiltmc/loader/api/plugin/QuiltLoaderPlugin.java
+++ b/src/main/java/org/quiltmc/loader/api/plugin/QuiltLoaderPlugin.java
@@ -174,4 +174,31 @@ public interface QuiltLoaderPlugin {
 	 * <p>
 	 * Most plugins are not expected to implement this. */
 	default void onLoadOptionRemoved(LoadOption option) {}
+
+	/**
+	 * This method allows removing load options from the mod list immediately before it is finalized and passed
+	 * to the transform cache, after solving.
+	 * The returned options are removed with no checks of any kind; they simply disappear from the mod list.
+	 * Since the solver will not be re-ran, no errors will occur due to missing dependencies or the like.
+	 * <p>
+	 *  Vetoes are performed in one pass: every plugin sees the initial mod list and provides vetoes, which are collected
+	 *  and applied together. Then, all plugins are made aware of vetoed mods (including the ones they vetoed themselves)
+	 *  through {@link #onModVeto(ModLoadOption)}.
+	 *  This is intended to allow plugins to "disable" mods that shouldn't load in the current environment, but need
+	 *  to be present during solving. <strong>Unless you have a very specific reason to use this, you should use
+	 *  {@link org.quiltmc.loader.api.plugin.solver.RuleContext#removeOption(LoadOption)} instead.</strong>
+	 * @param modList an immutable view of the mod list about to be loaded
+	 * @return the mods to be removed
+	 */
+	default ModLoadOption[] vetoMods(Collection<ModLoadOption> modList) {
+		return new ModLoadOption[0];
+	}
+
+	/**
+	 * Called after all vetoes from {@link #vetoMods(Collection)} of all plugins are collected and applied.
+	 * Plugins cannot undo vetoes or add mods to the mod list.
+	 * @param vetoedOption the option that was removed from the mod list
+	 */
+	default void onModVeto(ModLoadOption vetoedOption) {
+	}
 }

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -267,8 +267,9 @@ public final class QuiltLoaderImpl {
 	}
 
 	private void setup() throws ModResolutionException {
-
-		ModSolveResult result = runPlugins();
+		QuiltLoaderConfig config = new QuiltLoaderConfig(getConfigDir().resolve("quilt-loader.txt"));
+		QuiltPluginManagerImpl plugins = new QuiltPluginManagerImpl(getGameDir(), getConfigDir(), getModsDir(), provider, config);
+		ModSolveResult result = runPlugins(plugins);
 
 		SpecificLoadOptionResult<LoadOption> spec = result.getResult(LoadOption.class);
 
@@ -288,6 +289,8 @@ public final class QuiltLoaderImpl {
 		}
 
 		List<ModLoadOption> modList = new ArrayList<>(result.directMods().values());
+		plugins.vetoMods(modList); // removes vetoed mods directly from the list
+
 		Set<String> modIds = new HashSet<>();
 		for (ModLoadOption mod : modList) {
 			modIds.add(mod.id());
@@ -473,9 +476,9 @@ public final class QuiltLoaderImpl {
 		}
 	}
 
-	private ModSolveResult runPlugins() {
-		QuiltLoaderConfig config = new QuiltLoaderConfig(getConfigDir().resolve("quilt-loader.txt"));
-		QuiltPluginManagerImpl plugins = new QuiltPluginManagerImpl(getGameDir(), getConfigDir(), getModsDir(), provider, config);
+	private ModSolveResult runPlugins(QuiltPluginManagerImpl plugins) {
+
+
 
 		Path crashReportFile = null;
 		String fullCrashText = null;
@@ -488,7 +491,7 @@ public final class QuiltLoaderImpl {
 			}
 
 			boolean dev = isDevelopmentEnvironment();
-			boolean show = config.alwaysShowModStateWindow;
+			boolean show = plugins.config.alwaysShowModStateWindow;
 
 			if (!dev && !show) {
 				return result;

--- a/src/main/java/org/quiltmc/loader/impl/plugin/QuiltPluginManagerImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/QuiltPluginManagerImpl.java
@@ -629,6 +629,23 @@ public class QuiltPluginManagerImpl implements QuiltPluginManager {
 		}
 	}
 
+	public void vetoMods(List<ModLoadOption> modLoadOptions) {
+		List<ModLoadOption> toRemove = new ArrayList<>();
+		Collection<ModLoadOption> view = Collections.unmodifiableCollection(modLoadOptions);
+
+		for (QuiltLoaderPlugin plugin : plugins.keySet()) {
+			Collections.addAll(toRemove, plugin.vetoMods(view));
+		}
+
+		for (QuiltLoaderPlugin plugin : plugins.keySet()) {
+			for (ModLoadOption vetoedOption : toRemove) {
+				plugin.onModVeto(vetoedOption);
+			}
+		}
+
+		modLoadOptions.removeAll(toRemove);
+	}
+
 	public String createModTable() {
 		StringBuilder sb = new StringBuilder();
 		appendModTable(line -> {

--- a/src/main/java/org/quiltmc/loader/impl/plugin/QuiltPluginManagerImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/QuiltPluginManagerImpl.java
@@ -52,6 +52,7 @@ import java.util.zip.ZipException;
 import java.util.zip.ZipInputStream;
 
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 import org.quiltmc.loader.api.FasterFiles;
 import org.quiltmc.loader.api.LoaderValue;
 import org.quiltmc.loader.api.ModDependency;
@@ -144,7 +145,8 @@ public class QuiltPluginManagerImpl implements QuiltPluginManager {
 	private final StandardFabricPlugin theFabricPlugin;
 	private final BuiltinPluginContext theFabricPluginContext;
 
-	final Map<QuiltLoaderPlugin, BasePluginContext> plugins = new LinkedHashMap<>();
+	@VisibleForTesting
+	public final Map<QuiltLoaderPlugin, BasePluginContext> plugins = new LinkedHashMap<>();
 	final Map<String, QuiltPluginContextImpl> pluginsById = new HashMap<>();
 	final Map<String, QuiltPluginClassLoader> pluginsByPackage = new HashMap<>();
 

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/StandardQuiltPlugin.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/StandardQuiltPlugin.java
@@ -267,12 +267,7 @@ public class StandardQuiltPlugin extends BuiltinQuiltPlugin {
 				ctx.addRule(def);
 			}
 
-			// TODO: this minecraft-specific extension should be moved to its own plugin
-			// If the mod's environment doesn't match the current one,
-			// then add a rule so that the mod is never loaded.
-			if (!metadata.environment().matches(context().manager().getEnvironment())) {
-				ctx.addRule(new DisabledModIdDefinition(mod));
-			} else if (mod.isMandatory()) {
+			if (mod.isMandatory()) {
 				ctx.addRule(new MandatoryModIdDefinition(mod));
 			}
 
@@ -321,6 +316,12 @@ public class StandardQuiltPlugin extends BuiltinQuiltPlugin {
 				}
 			}
 		}
+	}
+
+	@Override
+	public ModLoadOption[] vetoMods(Collection<ModLoadOption> modList) {
+		// TODO: move to a Minecraft-specific plugin!
+		return modList.stream().filter(m -> !m.metadata().environment().matches(context().manager().getEnvironment())).toArray(ModLoadOption[]::new);
 	}
 
 	private static void warn(String msg) {


### PR DESCRIPTION
Summary of what a mod veto is, directly from the javadoc:
> Mod vetoes allow plugins to remove load options from the mod list immediately before it is finalized and passed to the transform cache, after solving. The returned options are removed with no checks of any kind; they simply disappear from the mod list. Since the solver will not be re-ran, no errors will occur due to missing dependencies or the like.
> Vetoes are performed in one pass: every plugin sees the initial mod list and submits vetoes, which are collected and applied together. Then, all plugins are made aware of vetoed mods (including the ones they vetoed themselves) through QuiltLoaderPlugin.onModVeto.
> **This is intended to allow plugins to "disable" mods that shouldn't load in the current environment, but need to be present during solving.**

This is a solution to #287 that exactly replicates the behavior of old Quilt Loader/Fabric Loader, but without special-casing the mechanism. In the future, we can move the removal of mods based on environment to a specific Minecraft Loader Plugin with almost no extra effort.

This PR targets the `release` branch (0.18) because the feature is directly related to a bugfix, and the bugfix is needed for QSL (and I'd like to get QSL on "modern" Loader as soon as possible)