### PR TITLE
Alternative improvements to the solver

### DIFF
--- a/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/MinecraftGameProvider.java
+++ b/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/MinecraftGameProvider.java
@@ -152,17 +152,7 @@ public class MinecraftGameProvider implements GameProvider {
 
 				@Override
 				public ModDependencyIdentifier id() {
-					return new ModDependencyIdentifier() {
-						@Override
-						public String mavenGroup() {
-							return "";
-						}
-
-						@Override
-						public String id() {
-							return "java";
-						}
-					};
+					return ModDependencyIdentifier.of("", "java");
 				}
 			});
 		}

--- a/src/main/java/org/quiltmc/loader/api/ModDependencyIdentifier.java
+++ b/src/main/java/org/quiltmc/loader/api/ModDependencyIdentifier.java
@@ -33,6 +33,9 @@ import org.quiltmc.loader.impl.metadata.qmj.ModDependencyIdentifierImpl;
 @ApiStatus.NonExtendable
 // TODO: document and make inner class
 public interface ModDependencyIdentifier {
+	static ModDependencyIdentifier of(String mavenGroup, String id) {
+		return new ModDependencyIdentifierImpl(mavenGroup, id);
+	}
 	/**
 	 * @return the maven group, or an empty string where no group requirement is specified
 	 */

--- a/src/main/java/org/quiltmc/loader/api/plugin/solver/LoadOption.java
+++ b/src/main/java/org/quiltmc/loader/api/plugin/solver/LoadOption.java
@@ -16,6 +16,7 @@
 
 package org.quiltmc.loader.api.plugin.solver;
 
+import org.quiltmc.loader.api.gui.QuiltLoaderText;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
 
@@ -24,4 +25,6 @@ import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
 @QuiltLoaderInternal(QuiltLoaderInternalType.PLUGIN_API)
 public abstract class LoadOption {
 
+	/** @return A description of this load option, to be shown in the error gui when this load option is involved in a solver error. */
+	public abstract QuiltLoaderText describe();
 }

--- a/src/main/java/org/quiltmc/loader/api/plugin/solver/Rule.java
+++ b/src/main/java/org/quiltmc/loader/api/plugin/solver/Rule.java
@@ -17,8 +17,10 @@
 package org.quiltmc.loader.api.plugin.solver;
 
 import java.util.Collection;
+import java.util.function.Consumer;
 
 import org.quiltmc.loader.api.ModDependency;
+import org.quiltmc.loader.api.gui.QuiltLoaderText;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
 
@@ -70,4 +72,6 @@ public abstract class Rule {
 	public abstract Collection<? extends LoadOption> getNodesTo();
 
 	public abstract void fallbackErrorDescription(StringBuilder errors);
+
+	public abstract void appendRuleDescription(Consumer<QuiltLoaderText> to);
 }

--- a/src/main/java/org/quiltmc/loader/impl/discovery/ArgumentModCandidateFinder.java
+++ b/src/main/java/org/quiltmc/loader/impl/discovery/ArgumentModCandidateFinder.java
@@ -117,7 +117,7 @@ public class ArgumentModCandidateFinder {
 					QuiltLoaderText.translate("error.arg_mods.not_folder.by.desc", original, source, path)
 				);
 			}
-			error.appendReportText("The file " + path + " is missing!");
+			error.appendReportText("The folder " + path + " is missing!");
 			error.appendReportText(" (It is specified by " + original + ")");
 			if (source != null) {
 				error.appendReportText(" (Inside the file " + source + ")");

--- a/src/main/java/org/quiltmc/loader/impl/plugin/QuiltPluginManagerImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/QuiltPluginManagerImpl.java
@@ -1205,6 +1205,7 @@ public class QuiltPluginManagerImpl implements QuiltPluginManager {
 
 	private void handleSolverFailure() throws TimeoutException {
 
+		SolverErrorHelper helper = new SolverErrorHelper(this);
 		boolean failed = false;
 
 		solver_error_iteration: do {
@@ -1232,7 +1233,7 @@ public class QuiltPluginManagerImpl implements QuiltPluginManager {
 						// Since this is an invalid state we'll report this error
 						// and report that the plugin did the wrong thing
 						failed = true;
-						reportSolverError(rules);
+						helper.reportSolverError(rules);
 						solver.removeRule(blamed);
 						reportError(theQuiltPluginContext, QuiltLoaderText.translate("plugin.illegal_state.recovered_and_blamed", ctx.pluginId));
 						return;
@@ -1251,7 +1252,7 @@ public class QuiltPluginManagerImpl implements QuiltPluginManager {
 					}
 				} else if (blamed != null) {
 					failed = true;
-					reportSolverError(rules);
+					helper.reportSolverError(rules);
 					solver.removeRule(blamed);
 					continue solver_error_iteration;
 				}
@@ -1261,7 +1262,7 @@ public class QuiltPluginManagerImpl implements QuiltPluginManager {
 			// So we'll just pick one of them randomly and remove it.
 
 			failed = true;
-			reportSolverError(rules);
+			helper.reportSolverError(rules);
 
 			Rule pickedRule = rules.stream().filter(r -> r instanceof QuiltRuleBreak).findAny().orElse(null);
 
@@ -1281,6 +1282,8 @@ public class QuiltPluginManagerImpl implements QuiltPluginManager {
 
 		} while (!solver.hasSolution());
 
+		helper.reportErrors();
+
 		if (failed) {
 			// Okay, so we failed but we've reached the end of the list of problems
 			// Just return here since the cycle handles this
@@ -1292,10 +1295,6 @@ public class QuiltPluginManagerImpl implements QuiltPluginManager {
 			reportError(theQuiltPluginContext, QuiltLoaderText.translate("solver.illegal_state.TODO"));
 			return;
 		}
-	}
-
-	private void reportSolverError(Collection<Rule> rules) {
-		SolverErrorHelper.reportSolverError(this, rules);
 	}
 
 	/** Checks for any {@link WarningLevel#FATAL} or {@link WarningLevel#ERROR} gui nodes, and throws an exception if

--- a/src/main/java/org/quiltmc/loader/impl/plugin/SolverErrorHelper.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/SolverErrorHelper.java
@@ -498,18 +498,14 @@ class SolverErrorHelper {
 
 	static class UnhandledError extends SolverError {
 
-		final List<Collection<Rule>> errors = new ArrayList<>();
+		final Collection<Rule> rules;
 
 		public UnhandledError(Collection<Rule> rules) {
-			errors.add(rules);
+			this.rules = rules;
 		}
 
 		@Override
 		boolean mergeInto(SolverError into) {
-			if (into instanceof UnhandledError) {
-				((UnhandledError) into).errors.addAll(errors);
-				return true;
-			}
 			return false;
 		}
 
@@ -523,21 +519,19 @@ class SolverErrorHelper {
 			error.appendReportText("Unhandled solver error involving the following rules:");
 
 			StringBuilder sb = new StringBuilder();
-			int errorIndex = 1;
-			for (Collection<Rule> rules : errors) {
-				error.appendReportText("Error " + errorIndex++ + ":");
-				int number = 1;
-				for (Rule rule : rules) {
-					error.appendReportText("Rule " + number++ + ":");
-					sb.setLength(0);
-					// TODO: Rename 'fallbackErrorDescription'
-					// to something like 'fallbackReportDescription'
-					// and then clean up all of the implementations to be more readable.
-					rule.fallbackErrorDescription(sb);
-					error.appendReportText(sb.toString());
-				}
-				error.appendReportText("");
+			int number = 1;
+			for (Rule rule : rules) {
+				error.appendDescription(QuiltLoaderText.translate("error.unhandled_solver.desc.rule_n", number, rule.getClass()));
+				rule.appendRuleDescription(error::appendDescription);
+				error.appendReportText("Rule " + number++ + ":");
+				sb.setLength(0);
+				// TODO: Rename 'fallbackErrorDescription'
+				// to something like 'fallbackReportDescription'
+				// and then clean up all of the implementations to be more readable.
+				rule.fallbackErrorDescription(sb);
+				error.appendReportText(sb.toString());
 			}
+			error.appendReportText("");
 		}
 	}
 

--- a/src/main/java/org/quiltmc/loader/impl/plugin/SolverErrorHelper.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/SolverErrorHelper.java
@@ -544,7 +544,7 @@ class SolverErrorHelper {
 	static class DependencyError extends SolverError {
 		final ModDependencyIdentifier modOn;
 		final VersionRange versionsOn;
-		final List<ModLoadOption> from = new ArrayList<>();
+		final Set<ModLoadOption> from = new LinkedHashSet<>();
 		final Set<ModLoadOption> allInvalidOptions;
 
 		DependencyError(ModDependencyIdentifier modOn, VersionRange versionsOn, ModLoadOption from, Set<ModLoadOption> allInvalidOptions) {
@@ -579,7 +579,7 @@ class SolverErrorHelper {
 
 			// Description:
 			// BuildCraft is loaded from '<mods>/buildcraft-9.0.0.jar'
-			ModLoadOption mandatoryMod = from.get(0);
+			ModLoadOption mandatoryMod = from.iterator().next();
 			String rootModName = from.size() > 1 ? from.size() + " mods" : mandatoryMod.metadata().name();
 
 			QuiltLoaderText first = VersionRangeDescriber.describe(rootModName, versionsOn, modOn.id(), transitive);

--- a/src/main/java/org/quiltmc/loader/impl/plugin/SolverErrorHelper.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/SolverErrorHelper.java
@@ -515,7 +515,7 @@ class SolverErrorHelper {
 				QuiltLoaderText.translate("error.unhandled_solver")
 			);
 			error.appendDescription(QuiltLoaderText.of("error.unhandled_solver.desc"));
-			error.addOpenLinkButton(QuiltLoaderText.of("button.quilt_loader_report"), "https://github.com/QuiltMC/quilt-loader/issues");
+			error.addOpenQuiltSupportButton();
 			error.appendReportText("Unhandled solver error involving the following rules:");
 
 			StringBuilder sb = new StringBuilder();

--- a/src/main/java/org/quiltmc/loader/impl/plugin/VersionRangeDescriber.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/VersionRangeDescriber.java
@@ -19,13 +19,20 @@ package org.quiltmc.loader.impl.plugin;
 import org.quiltmc.loader.api.VersionInterval;
 import org.quiltmc.loader.api.VersionRange;
 import org.quiltmc.loader.api.gui.QuiltLoaderText;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
 
-class VersionRangeDescriber {
-	static QuiltLoaderText describe(String modName, VersionRange range, String depName, boolean transitive) {
+@QuiltLoaderInternal(QuiltLoaderInternalType.NEW_INTERNAL)
+public class VersionRangeDescriber {
+	public static QuiltLoaderText describe(String modName, VersionRange range, String depName, boolean transitive) {
+		return describe(QuiltLoaderText.of(modName), range, depName, transitive);
+	}
+
+	public static QuiltLoaderText describe(QuiltLoaderText modFrom, VersionRange range, String depName, boolean transitive) {
 		String titleKey = "error.dep." + (transitive ? "transitive." : "direct.");
 
 		if (range.size() != 1) {
-			return QuiltLoaderText.translate(getTransKey(titleKey, "ranged"), modName, range, depName);
+			return QuiltLoaderText.translate(getTransKey(titleKey, "ranged"), modFrom, range, depName);
 		}
 
 		VersionInterval interval = range.first();
@@ -34,25 +41,25 @@ class VersionRangeDescriber {
 		if (interval.getMin() == null) {
 			// Positive infinity
 			if (interval.getMax() == null) {
-				return QuiltLoaderText.translate(getTransKey(titleKey, "any"), modName, depName);
+				return QuiltLoaderText.translate(getTransKey(titleKey, "any"), modFrom, depName);
 			} else {
-				return QuiltLoaderText.translate(getTransKey(titleKey, interval.isMaxInclusive() ? "lesser_equal" : "lesser"), modName, interval.getMax(), depName);
+				return QuiltLoaderText.translate(getTransKey(titleKey, interval.isMaxInclusive() ? "lesser_equal" : "lesser"), modFrom, interval.getMax(), depName);
 			}
 		}
 
 		// positive infinity
 		if (interval.getMax() == null) {
-			return QuiltLoaderText.translate(getTransKey(titleKey, interval.isMinInclusive() ? "greater_equal" : "greater"), modName, interval.getMin(), depName);
+			return QuiltLoaderText.translate(getTransKey(titleKey, interval.isMinInclusive() ? "greater_equal" : "greater"), modFrom, interval.getMin(), depName);
 		}
 
 		if (interval.getMax().equals(interval.getMin())) {
-			return QuiltLoaderText.translate(getTransKey(titleKey, "exact"), modName, interval.getMax(), depName);
+			return QuiltLoaderText.translate(getTransKey(titleKey, "exact"), modFrom, interval.getMax(), depName);
 		}
 
 		// ranged
 		String extra = "range_" + (interval.isMinInclusive() ? "inc_" : "exc_") + (interval.isMaxInclusive() ? "inc" : "exc");
 
-		return QuiltLoaderText.translate(getTransKey(titleKey, extra), modName, interval.getMin(), interval.getMax(), depName);
+		return QuiltLoaderText.translate(getTransKey(titleKey, extra), modFrom, interval.getMin(), interval.getMax(), depName);
 	}
 
 	private static String getTransKey(String titleKey, String extra) {

--- a/src/main/java/org/quiltmc/loader/impl/plugin/base/InternalModOptionBase.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/base/InternalModOptionBase.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 
 import org.jetbrains.annotations.Nullable;
 import org.quiltmc.loader.api.gui.QuiltLoaderIcon;
+import org.quiltmc.loader.api.gui.QuiltLoaderText;
 import org.quiltmc.loader.api.plugin.ModMetadataExt;
 import org.quiltmc.loader.api.plugin.QuiltPluginContext;
 import org.quiltmc.loader.api.plugin.solver.ModLoadOption;
@@ -96,6 +97,13 @@ public abstract class InternalModOptionBase extends ModLoadOption {
 	@Override
 	public String getSpecificInfo() {
 		return toString();
+	}
+
+	protected abstract String nameOfType();
+
+	@Override
+	public QuiltLoaderText describe() {
+		return QuiltLoaderText.translate("solver.option.mod.quilt_impl", nameOfType(), metadata.id(), pluginContext.manager().describePath(from));
 	}
 
 	@Override

--- a/src/main/java/org/quiltmc/loader/impl/plugin/fabric/FabricModOption.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/fabric/FabricModOption.java
@@ -42,6 +42,11 @@ public class FabricModOption extends InternalModOptionBase {
 	}
 
 	@Override
+	protected String nameOfType() {
+		return "fabric";
+	}
+
+	@Override
 	public ModContainerExt convertToMod(Path transformedResourceRoot) {
 		return new FabricModContainer(pluginContext, metadata, from, transformedResourceRoot);
 	}

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/BuiltinModOption.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/BuiltinModOption.java
@@ -46,6 +46,11 @@ public class BuiltinModOption extends InternalModOptionBase {
 	}
 
 	@Override
+	protected String nameOfType() {
+		return "builtin";
+	}
+
+	@Override
 	public ModContainerExt convertToMod(Path transformedResourceRoot) {
 		if (!transformedResourceRoot.equals(resourceRoot)) {
 			try {

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/DisabledModIdDefinition.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/DisabledModIdDefinition.java
@@ -16,6 +16,10 @@
 
 package org.quiltmc.loader.impl.plugin.quilt;
 
+import java.util.function.Consumer;
+
+import org.quiltmc.loader.api.gui.QuiltLoaderText;
+import org.quiltmc.loader.api.plugin.QuiltPluginContext;
 import org.quiltmc.loader.api.plugin.solver.LoadOption;
 import org.quiltmc.loader.api.plugin.solver.ModLoadOption;
 import org.quiltmc.loader.api.plugin.solver.RuleDefiner;
@@ -26,9 +30,11 @@ import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
 @QuiltLoaderInternal(QuiltLoaderInternalType.NEW_INTERNAL)
 public final class DisabledModIdDefinition extends ModIdDefinition {
 	public final ModLoadOption option;
+	private final QuiltPluginContext ctx;
 
-	public DisabledModIdDefinition(ModLoadOption candidate) {
+	public DisabledModIdDefinition(QuiltPluginContext ctx, ModLoadOption candidate) {
 		this.option = candidate;
+		this.ctx = ctx;
 	}
 
 	@Override
@@ -72,5 +78,11 @@ public final class DisabledModIdDefinition extends ModIdDefinition {
 		errors.append(getFriendlyName());
 		errors.append(" v");
 		errors.append(option.metadata().version());
+	}
+
+	@Override
+	public void appendRuleDescription(Consumer<QuiltLoaderText> to) {
+		String from = ctx.manager().describePath(option.from());
+		to.accept(QuiltLoaderText.translate("solver.rule.mod_def.disabled", getModId(), option.metadata().version(), from));
 	}
 }

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/MandatoryModIdDefinition.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/MandatoryModIdDefinition.java
@@ -16,6 +16,10 @@
 
 package org.quiltmc.loader.impl.plugin.quilt;
 
+import java.util.function.Consumer;
+
+import org.quiltmc.loader.api.gui.QuiltLoaderText;
+import org.quiltmc.loader.api.plugin.QuiltPluginContext;
 import org.quiltmc.loader.api.plugin.solver.LoadOption;
 import org.quiltmc.loader.api.plugin.solver.ModLoadOption;
 import org.quiltmc.loader.api.plugin.solver.RuleDefiner;
@@ -28,9 +32,11 @@ import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
 @QuiltLoaderInternal(QuiltLoaderInternalType.NEW_INTERNAL)
 public final class MandatoryModIdDefinition extends ModIdDefinition {
 	public final ModLoadOption option;
+	private final QuiltPluginContext ctx;
 
-	public MandatoryModIdDefinition(ModLoadOption candidate) {
+	public MandatoryModIdDefinition(QuiltPluginContext ctx, ModLoadOption candidate) {
 		this.option = candidate;
+		this.ctx = ctx;
 	}
 
 	@Override
@@ -74,5 +80,11 @@ public final class MandatoryModIdDefinition extends ModIdDefinition {
 		errors.append(getFriendlyName());
 		errors.append(" v");
 		errors.append(option.metadata().version());
+	}
+
+	@Override
+	public void appendRuleDescription(Consumer<QuiltLoaderText> to) {
+		String from = ctx.manager().describePath(option.from());
+		to.accept(QuiltLoaderText.translate("solver.rule.mod_def.mandatory", getModId(), option.metadata().version(), from));
 	}
 }

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/OptionalModIdDefintion.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/OptionalModIdDefintion.java
@@ -19,8 +19,10 @@ package org.quiltmc.loader.impl.plugin.quilt;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.quiltmc.loader.api.Version;
+import org.quiltmc.loader.api.gui.QuiltLoaderText;
 import org.quiltmc.loader.api.plugin.QuiltPluginManager;
 import org.quiltmc.loader.api.plugin.ModMetadataExt.ModLoadType;
 import org.quiltmc.loader.api.plugin.solver.AliasedLoadOption;
@@ -172,6 +174,14 @@ public final class OptionalModIdDefintion extends ModIdDefinition {
 		for (ModLoadOption option : sources) {
 			errors.append("\n\t - ");
 			errors.append(option.getSpecificInfo());
+		}
+	}
+
+	@Override
+	public void appendRuleDescription(Consumer<QuiltLoaderText> to) {
+		to.accept(QuiltLoaderText.translate("solver.rule.mod_def.optional", modid, sources.size()));
+		for (ModLoadOption mod : sources) {
+			to.accept(QuiltLoaderText.translate("solver.rule.mod_def.optional.source", mod.describe()));
 		}
 	}
 }

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/ProvidedModOption.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/ProvidedModOption.java
@@ -81,6 +81,11 @@ public class ProvidedModOption extends ModLoadOption implements AliasedLoadOptio
 	}
 
 	@Override
+	public QuiltLoaderText describe() {
+		return QuiltLoaderText.translate("solver.option.mod.quilt_impl", "provided", id() + " " + version(), provider.describe());
+	}
+
+	@Override
 	@NotNull
 	public ModLoadOption getTarget() {
 		return provider;

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/QuiltModDepOption.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/QuiltModDepOption.java
@@ -16,7 +16,10 @@
 
 package org.quiltmc.loader.impl.plugin.quilt;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.quiltmc.loader.api.ModDependency;
+import org.quiltmc.loader.api.gui.QuiltLoaderText;
 import org.quiltmc.loader.api.plugin.solver.LoadOption;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
@@ -24,7 +27,10 @@ import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
 /** Used to indicate part of a {@link ModDependency} from quilt.mod.json. */
 @QuiltLoaderInternal(QuiltLoaderInternalType.NEW_INTERNAL)
 public class QuiltModDepOption extends LoadOption {
+	private static final AtomicInteger IDS = new AtomicInteger();
+
 	public final ModDependency dep;
+	private final int id = IDS.incrementAndGet();
 
 	public QuiltModDepOption(ModDependency dep) {
 		this.dep = dep;
@@ -33,5 +39,10 @@ public class QuiltModDepOption extends LoadOption {
 	@Override
 	public String toString() {
 		return dep.toString();
+	}
+
+	@Override
+	public QuiltLoaderText describe() {
+		return QuiltLoaderText.translate("solver.option.dep_technical", id, dep.toString());
 	}
 }

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/QuiltModOption.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/QuiltModOption.java
@@ -45,4 +45,9 @@ public class QuiltModOption extends InternalModOptionBase {
 	public ModContainerExt convertToMod(Path transformedResourceRoot) {
 		return new QuiltModContainer(pluginContext, metadata, from, transformedResourceRoot);
 	}
+
+	@Override
+	protected String nameOfType() {
+		return "quilt";
+	}
 }

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/QuiltRuleBreakAll.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/QuiltRuleBreakAll.java
@@ -20,8 +20,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.quiltmc.loader.api.ModDependency;
+import org.quiltmc.loader.api.gui.QuiltLoaderText;
 import org.quiltmc.loader.api.plugin.QuiltPluginManager;
 import org.quiltmc.loader.api.plugin.solver.LoadOption;
 import org.quiltmc.loader.api.plugin.solver.RuleContext;
@@ -117,6 +119,14 @@ public class QuiltRuleBreakAll extends QuiltRuleBreak {
 			errors.append("\n\t-");
 			errors.append(on.source);
 			errors.append(" ");
+		}
+	}
+
+	@Override
+	public void appendRuleDescription(Consumer<QuiltLoaderText> to) {
+		to.accept(QuiltLoaderText.translate("solver.rule.break.all", source.describe()));
+		for (QuiltRuleBreakOnly on : options) {
+			to.accept(on.source.describe());
 		}
 	}
 }

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/QuiltRuleBreakOnly.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/QuiltRuleBreakOnly.java
@@ -20,13 +20,16 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.quiltmc.loader.api.ModDependency;
+import org.quiltmc.loader.api.gui.QuiltLoaderText;
 import org.quiltmc.loader.api.plugin.QuiltPluginManager;
 import org.quiltmc.loader.api.plugin.solver.LoadOption;
 import org.quiltmc.loader.api.plugin.solver.ModLoadOption;
 import org.quiltmc.loader.api.plugin.solver.RuleContext;
 import org.quiltmc.loader.api.plugin.solver.RuleDefiner;
+import org.quiltmc.loader.impl.plugin.VersionRangeDescriber;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
 import org.quiltmc.loader.impl.util.log.Log;
@@ -170,6 +173,25 @@ public class QuiltRuleBreakOnly extends QuiltRuleBreak {
 
 		for (ModLoadOption option : okayOptions) {
 			errors.append("\n\t+ " + option.fullString());
+		}
+	}
+
+	@Override
+	public void appendRuleDescription(Consumer<QuiltLoaderText> to) {
+		StringBuilder id = new StringBuilder(publicDep.id().mavenGroup());
+		if (id.length() > 0) {
+			id.append(":");
+		}
+		id.append(publicDep.id().id());
+		Object on = VersionRangeDescriber.describe(source.describe(), publicDep.versionRange(), id.toString(), false);
+		to.accept(QuiltLoaderText.translate("solver.rule.break.only", on));
+		to.accept(QuiltLoaderText.translate("solver.rule.break.only.conflicting", conflictingOptions.size()));
+		for (ModLoadOption option : conflictingOptions) {
+			to.accept(QuiltLoaderText.translate("solver.rule.mod_def.optional.source", option.describe()));
+		}
+		to.accept(QuiltLoaderText.translate("solver.rule.break.only.invalid", okayOptions.size()));
+		for (ModLoadOption option : okayOptions) {
+			to.accept(QuiltLoaderText.translate("solver.rule.mod_def.optional.source", option.describe()));
 		}
 	}
 }

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/QuiltRuleDepAny.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/QuiltRuleDepAny.java
@@ -20,8 +20,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.quiltmc.loader.api.ModDependency;
+import org.quiltmc.loader.api.gui.QuiltLoaderText;
 import org.quiltmc.loader.api.plugin.QuiltPluginManager;
 import org.quiltmc.loader.api.plugin.solver.LoadOption;
 import org.quiltmc.loader.api.plugin.solver.RuleContext;
@@ -116,6 +118,14 @@ public class QuiltRuleDepAny extends QuiltRuleDep {
 			errors.append("\n\t-");
 			errors.append(on.source);
 			errors.append(" ");
+		}
+	}
+
+	@Override
+	public void appendRuleDescription(Consumer<QuiltLoaderText> to) {
+		to.accept(QuiltLoaderText.translate("solver.rule.dep.any", source.describe()));
+		for (QuiltRuleDepOnly on : options) {
+			to.accept(on.source.describe());
 		}
 	}
 }

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/QuiltRuleDepOnly.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/QuiltRuleDepOnly.java
@@ -21,15 +21,18 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.quiltmc.loader.api.ModDependency;
 import org.quiltmc.loader.api.VersionInterval;
+import org.quiltmc.loader.api.gui.QuiltLoaderText;
 import org.quiltmc.loader.api.minecraft.MinecraftQuiltLoader;
 import org.quiltmc.loader.api.plugin.QuiltPluginManager;
 import org.quiltmc.loader.api.plugin.solver.LoadOption;
 import org.quiltmc.loader.api.plugin.solver.ModLoadOption;
 import org.quiltmc.loader.api.plugin.solver.RuleContext;
 import org.quiltmc.loader.api.plugin.solver.RuleDefiner;
+import org.quiltmc.loader.impl.plugin.VersionRangeDescriber;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
 import org.quiltmc.loader.impl.util.log.Log;
@@ -218,6 +221,25 @@ public class QuiltRuleDepOnly extends QuiltRuleDep {
 
 		for (ModLoadOption option : invalidOptions) {
 			errors.append("\n\tx " + option.fullString());
+		}
+	}
+
+	@Override
+	public void appendRuleDescription(Consumer<QuiltLoaderText> to) {
+		StringBuilder id = new StringBuilder(publicDep.id().mavenGroup());
+		if (id.length() > 0) {
+			id.append(":");
+		}
+		id.append(publicDep.id().id());
+		Object on = VersionRangeDescriber.describe(source.describe(), publicDep.versionRange(), id.toString(), false);
+		to.accept(QuiltLoaderText.translate("solver.rule.dep.only", on));
+		to.accept(QuiltLoaderText.translate("solver.rule.dep.only.matching", validOptions.size()));
+		for (ModLoadOption option : validOptions) {
+			to.accept(QuiltLoaderText.translate("solver.rule.mod_def.optional.source", option.describe()));
+		}
+		to.accept(QuiltLoaderText.translate("solver.rule.dep.only.invalid", invalidOptions.size()));
+		for (ModLoadOption option : invalidOptions) {
+			to.accept(QuiltLoaderText.translate("solver.rule.mod_def.optional.source", option.describe()));
 		}
 	}
 }

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/StandardQuiltPlugin.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/StandardQuiltPlugin.java
@@ -315,9 +315,9 @@ public class StandardQuiltPlugin extends BuiltinQuiltPlugin {
 			// If the mod's environment doesn't match the current one,
 			// then add a rule so that the mod is never loaded.
 			if (!metadata.environment().matches(context().manager().getEnvironment())) {
-				ctx.addRule(new DisabledModIdDefinition(mod));
+				ctx.addRule(new DisabledModIdDefinition(context(), mod));
 			} else if (mod.isMandatory()) {
-				ctx.addRule(new MandatoryModIdDefinition(mod));
+				ctx.addRule(new MandatoryModIdDefinition(context(), mod));
 			}
 
 			if (metadata.shouldQuiltDefineProvides()) {

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/SystemModOption.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/SystemModOption.java
@@ -37,6 +37,11 @@ public class SystemModOption extends BuiltinModOption {
 	}
 
 	@Override
+	protected String nameOfType() {
+		return "system";
+	}
+
+	@Override
 	public byte[] computeOriginHash() throws IOException {
 		return new byte[] { 0, 1, 2, 3 };
 	}

--- a/src/main/java/org/quiltmc/loader/impl/solver/NegatedLoadOption.java
+++ b/src/main/java/org/quiltmc/loader/impl/solver/NegatedLoadOption.java
@@ -16,6 +16,7 @@
 
 package org.quiltmc.loader.impl.solver;
 
+import org.quiltmc.loader.api.gui.QuiltLoaderText;
 import org.quiltmc.loader.api.plugin.solver.LoadOption;
 import org.quiltmc.loader.api.plugin.solver.Rule;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
@@ -34,5 +35,10 @@ final class NegatedLoadOption extends LoadOption {
 	@Override
 	public String toString() {
 		return "NOT " + not;
+	}
+
+	@Override
+	public QuiltLoaderText describe() {
+		return QuiltLoaderText.translate("solver.option.negated", not.describe());
 	}
 }

--- a/src/main/resources/lang/quilt_loader.properties
+++ b/src/main/resources/lang/quilt_loader.properties
@@ -61,8 +61,9 @@ gui.error.ioexception.desc.0=%s
 gui.text.invalid_metadata=Invalid Metadata: %s
 gui.text.invalid_metadata.title=Unable to read %s: %s
 gui.text.invalid_metadata.desc.0=From %s
-error.unhandled_solver=Unhandled solver error; see the crash report for more information
+error.unhandled_solver=Complex solver error; see the crash report for more information
 error.unhandled_solver.desc=Please try updating quilt-loader to see if an update can describe this.\nOr report this to the quilt-loader project so this can be fixed.
+error.unhandled_solver.desc.rule_n= \n \nRule %s (%s):
 fabric.jar_in_jar.missing=Included file not found!
 error.duplicate_mandatory=Duplicate mod: %s
 error.duplicate_mandatory.mod=- %s
@@ -104,3 +105,22 @@ error.arg_mods.missing.by.desc=It is specified by %s (inside %s), and must be pr
 error.arg_mods.not_folder.title=Specified a folder, but %s is a file!
 error.arg_mods.not_folder.desc=Cannot scan a file for sub-mods.\nIt is specified by %s, and must be present.\nFull path: %s
 error.arg_mods.not_folder.by.desc=Cannot scan a file for sub-mods.\nIt is specified by %s (inside %s), and must be present.\nFull path: %s
+
+# Solver Rules
+solver.rule.mod_def.mandatory=Mandatory Mod '%s', version '%s', loaded from %s
+solver.rule.mod_def.disabled=Disabled Mod '%s', version '%s', loaded from %s
+solver.rule.mod_def.optional=Optional Mod '%s' with %s sources:
+solver.rule.mod_def.optional.source= - %s
+solver.rule.dep.only=Dependency: %s
+solver.rule.dep.only.matching=%s matching options:
+solver.rule.dep.only.invalid=%s invalid options:
+solver.rule.dep.only=Breakage: %s
+solver.rule.dep.only.conflicting=%s conflicting options:
+solver.rule.dep.only.okay=%s okay options:
+solver.rule.dep.any=%s depends on any of:
+solver.rule.break.all=%s breaks with all of:
+
+# Solver LoadOptions
+solver.option.negated=Negation of %s
+solver.option.mod.quilt_impl=%s mod %s from %s
+solver.option.dep_technical=Technical load option #%s, representing %s


### PR DESCRIPTION
This uses a few of the general improvements that @TheGlitch76 wrote in #305, but doesn't discard the previous solver helper - which results in this error screen when adding the wrong version of QSL into the mods folder (compare against [these images](https://github.com/QuiltMC/quilt-loader/pull/305#issuecomment-1546785194))

![Screenshot from 2023-05-14 02-32-12](https://github.com/QuiltMC/quilt-loader/assets/3751138/e5d7b4e5-9728-408f-8f21-42c5c458ee81)

Similar to #305 this has a few problems: some mods are included multiple times in the list (likely due to their dependency chains being slightly different), and it doesn't show what those dependency chains are. I'm not sure how important this is though.

(This also fixes "provided" mods not being recognized by the solver helper)