### PR TITLE
Active user beacon

### DIFF
--- a/src/main/java/org/quiltmc/loader/api/QuiltLoader.java
+++ b/src/main/java/org/quiltmc/loader/api/QuiltLoader.java
@@ -28,6 +28,7 @@ import org.jetbrains.annotations.Nullable;
 import org.quiltmc.loader.api.entrypoint.EntrypointContainer;
 import org.quiltmc.loader.api.entrypoint.EntrypointException;
 import org.quiltmc.loader.impl.QuiltLoaderImpl;
+import org.quiltmc.loader.impl.util.GlobalPaths;
 
 import net.fabricmc.api.EnvType;
 
@@ -222,6 +223,20 @@ public final class QuiltLoader {
 	 */
 	public static Path getConfigDir() {
 		return impl().getConfigDir();
+	}
+
+	/**
+	 * Get the global (per-user) directory for cached files.
+	 */
+	public static Path getGlobalCacheDir() {
+		return GlobalPaths.getCacheDir();
+	}
+
+	/**
+	 * Get the global (per-user) directory for configuration files.
+	 */
+	public static Path getGlobalConfigDir() {
+		return GlobalPaths.getConfigDir();
 	}
 
 	/**

--- a/src/main/java/org/quiltmc/loader/impl/ActiveUserBeacon.java
+++ b/src/main/java/org/quiltmc/loader/impl/ActiveUserBeacon.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.loader.impl;
 
 import java.io.IOException;

--- a/src/main/java/org/quiltmc/loader/impl/ActiveUserBeacon.java
+++ b/src/main/java/org/quiltmc/loader/impl/ActiveUserBeacon.java
@@ -39,7 +39,7 @@ class ActiveUserBeacon {
 	private static final String ENVIRONMENT = "QUILT_LOADER_DISABLE_BEACON";
 	private static final String ENVIRONMENT_CI = "CI";
 
-	private static final String INFO_SUFFIX = " # Last sent month for the active user beacon. See [BLOG_LINK] for details.";
+	private static final String INFO_SUFFIX = " # Last sent month for the active user beacon. See https://quiltmc.org/en/blog/2023-06-26-mau-beacon/ for details.";
 
 	static Path configFile;
 	static byte[] thisMonthBytes = new byte[0];

--- a/src/main/java/org/quiltmc/loader/impl/ActiveUserBeacon.java
+++ b/src/main/java/org/quiltmc/loader/impl/ActiveUserBeacon.java
@@ -1,0 +1,111 @@
+package org.quiltmc.loader.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+
+import org.quiltmc.loader.api.QuiltLoader;
+import org.quiltmc.loader.impl.gui.QuiltForkComms;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
+import org.quiltmc.loader.impl.util.SystemProperties;
+import org.quiltmc.loader.impl.util.log.Log;
+import org.quiltmc.loader.impl.util.log.LogCategory;
+
+@QuiltLoaderInternal(QuiltLoaderInternalType.NEW_INTERNAL)
+class ActiveUserBeacon {
+
+	private static final String ENVIRONMENT = "QUILT_LOADER_DISABLE_BEACON";
+	private static final String ENVIRONMENT_CI = "CI";
+
+	private static final String INFO_SUFFIX = " # Last sent month for the active user beacon. See [BLOG_LINK] for details.";
+
+	static Path configFile;
+	static byte[] thisMonthBytes = new byte[0];
+
+	static void run() {
+		if (Boolean.getBoolean(SystemProperties.DISABLE_BEACON)) {
+			return;
+		}
+		if (Boolean.parseBoolean(getEnv(ENVIRONMENT))) {
+			return;
+		}
+		if (Boolean.parseBoolean(getEnv(ENVIRONMENT_CI))) {
+			return;
+		}
+
+		// Just in case
+		if (QuiltForkComms.isServer()) {
+			return;
+		}
+
+		Path globalConfig = QuiltLoader.getGlobalConfigDir();
+		configFile = globalConfig.resolve(QuiltLoaderImpl.MOD_ID).resolve("ActiveUserBeacon.txt");
+		thisMonthBytes = LocalDateTime.now().getMonth().toString().getBytes(StandardCharsets.UTF_8);
+		if (Files.exists(configFile)) {
+			try (InputStream stream = Files.newInputStream(configFile)) {
+				boolean different = false;
+				for (int i = 0; i < thisMonthBytes.length; i++) {
+					byte expected = thisMonthBytes[0];
+					int got = stream.read();
+					if (expected != got) {
+						different = true;
+						break;
+					}
+				}
+				if (!different) {
+					return;
+				}
+			} catch (IOException io) {
+				throw new Error("Failed to read " + globalConfig, io);
+			}
+		}
+
+		Thread thread = new Thread(ActiveUserBeacon::runOnThread, "Quilt Loader Active User Beacon");
+		thread.setDaemon(true);
+		thread.start();
+
+		thread.getId();
+	}
+
+	private static String getEnv(String key) {
+		String value = System.getenv(key);
+		if (value == null) {
+			return "";
+		}
+		return value;
+	}
+
+	private static void runOnThread() {
+		try {
+			URL url = new URL("https://beacon.quiltmc.org/signal");
+
+			HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+
+			// Replace the java version with one that doesn't include versioning information
+			connection.setRequestProperty("User-Agent", "Quilt-Loader");
+
+			connection.setRequestMethod("POST");
+			connection.getResponseCode();
+
+			if (!Files.isDirectory(configFile.getParent())) {
+				Files.createDirectories(configFile.getParent());
+			}
+
+			byte[] info = INFO_SUFFIX.getBytes(StandardCharsets.UTF_8);
+			byte[] total = new byte[thisMonthBytes.length + info.length];
+			System.arraycopy(thisMonthBytes, 0, total, 0, thisMonthBytes.length);
+			System.arraycopy(info, 0, total, thisMonthBytes.length, info.length);
+			Files.write(configFile, total);
+
+		} catch (IOException e) {
+			Log.warn(LogCategory.GENERAL, "Failed to notify the beacon - trying again next launch.", e);
+			return;
+		}
+	}
+}

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -199,6 +199,8 @@ public final class QuiltLoaderImpl {
 
 		setGameDir(provider.getLaunchDirectory());
 		argumentModsList = provider.getArguments().remove(Arguments.ADD_MODS);
+
+		ActiveUserBeacon.run();
 	}
 
 	public void setGameDir(Path gameDir) {
@@ -234,7 +236,7 @@ public final class QuiltLoaderImpl {
 		return gameDir;
 	}
 
-	private Path ensureDirExists(Path path, String name) {
+	public static Path ensureDirExists(Path path, String name) {
 		if (path == null) {
 			// May be null during tests for cache and config directories
 			// If this is in production then things are about to go very wrong.

--- a/src/main/java/org/quiltmc/loader/impl/util/GlobalPaths.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/GlobalPaths.java
@@ -1,0 +1,98 @@
+package org.quiltmc.loader.impl.util;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+
+import org.quiltmc.loader.impl.QuiltLoaderImpl;
+
+@QuiltLoaderInternal(QuiltLoaderInternalType.NEW_INTERNAL)
+public class GlobalPaths {
+
+	private static Path config, cache;
+
+	public static Path getConfigDir() {
+		if (config == null) {
+			String os = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+
+			if (os.contains("win")) {
+				String configHome = System.getenv("LOCALAPPDATA");
+				Path base = Paths.get(configHome);
+				if (!Files.exists(base)) {
+					throw new Error("Bad LOCALAPPDATA '" + configHome + "'");
+				}
+
+				config = base.resolve("QuiltMC").resolve("QuiltLoaderAndMods");
+
+			} else if (os.contains("mac")) {
+
+				Path home = Paths.get(System.getProperty("user.home"));
+				Path base = home.resolve("Library").resolve("Application Support");
+
+				config = base.resolve("org.quiltmc.QuiltLoaderAndMods");
+
+			} else {
+				String configHome = System.getenv("XDG_CONFIG_HOME");
+				if (configHome == null) {
+					configHome = System.getProperty("user.home");
+					if (!configHome.endsWith("/")) {
+						configHome += "/";
+					}
+					configHome += ".config";
+				}
+				Path base = Paths.get(configHome);
+				if (!Files.exists(base)) {
+					throw new Error("Bad XDG_CONFIG_HOME '" + configHome + "'");
+				}
+
+				config = base.resolve("quilt_loader_and_mods");
+			}
+
+			QuiltLoaderImpl.ensureDirExists(config, "global config");
+		}
+		return config;
+	}
+
+	public static Path getCacheDir() {
+		if (cache == null) {
+			String os = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+
+			if (os.contains("win")) {
+				String configHome = System.getenv("LOCALAPPDATA");
+				Path base = Paths.get(configHome);
+				if (!Files.exists(base)) {
+					throw new Error("Bad LOCALAPPDATA '" + configHome + "'");
+				}
+
+				cache = base.resolve("QuiltMC").resolve("QuiltLoaderAndMods").resolve("Cache");
+
+			} else if (os.contains("mac")) {
+
+				Path home = Paths.get(System.getProperty("user.home"));
+				Path base = home.resolve("Library").resolve("Caches");
+
+				cache = base.resolve("org.quiltmc.QuiltLoaderAndMods");
+
+			} else {
+				String cacheHome = System.getenv("XDG_CACHE_HOME");
+				if (cacheHome == null) {
+					cacheHome = System.getProperty("user.home");
+					if (!cacheHome.endsWith("/")) {
+						cacheHome += "/";
+					}
+					cacheHome += ".cache";
+				}
+				Path base = Paths.get(cacheHome);
+				if (!Files.exists(base)) {
+					throw new Error("Bad XDG_CACHE_HOME '" + cacheHome + "'");
+				}
+
+				cache = base.resolve("quilt_loader_and_mods");
+			}
+
+			QuiltLoaderImpl.ensureDirExists(cache, "global cache");
+		}
+		return cache;
+	}
+}

--- a/src/main/java/org/quiltmc/loader/impl/util/GlobalPaths.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/GlobalPaths.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.loader.impl.util;
 
 import java.nio.file.Files;

--- a/src/main/java/org/quiltmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/SystemProperties.java
@@ -73,6 +73,7 @@ public final class SystemProperties {
 	public static final String DISABLE_OPTIMIZED_COMPRESSED_TRANSFORM_CACHE = "loader.transform_cache.disable_optimised_compression";
 	public static final String DISABLE_PRELOAD_TRANSFORM_CACHE = "loader.transform_cache.disable_preload";
 	public static final String LOG_CACHE_KEY_CHANGES = "loader.transform_cache.log_changed_keys";
+	public static final String DISABLE_BEACON = "loader.disable_beacon";
 
 	private SystemProperties() {
 	}

--- a/src/main/resources/changelog/0.19.2.txt
+++ b/src/main/resources/changelog/0.19.2.txt
@@ -6,6 +6,8 @@ Features:
     - See https://github.com/QuiltMC/rfcs/pull/56 for more details.
 - Added warnings when encountering dependency constraints that are unnecessary.
 - [#326] Added an Active User Beacon, outlined in RFC 81.
+    - Please see the RFC for details: https://github.com/QuiltMC/rfcs/blob/main/specification/0081-active-user-beacon.md
+    - Or the blog post: https://quiltmc.org/en/blog/2023-06-26-mau-beacon/
 - Added global config and cache paths to the QuiltLoader api class:
     - "getGlobalConfigDir" and "getGlobalCacheDir".
     - The config path depends on the operating system:

--- a/src/main/resources/changelog/0.19.2.txt
+++ b/src/main/resources/changelog/0.19.2.txt
@@ -6,6 +6,18 @@ Features:
     - See https://github.com/QuiltMC/rfcs/pull/56 for more details.
 - Added warnings when encountering dependency constraints that are unnecessary.
 - [#326] Added an Active User Beacon, outlined in RFC 81.
+- Added global config and cache paths to the QuiltLoader api class:
+    - "getGlobalConfigDir" and "getGlobalCacheDir".
+    - The config path depends on the operating system:
+        - "%LOCALAPPDATA%\QuiltMC\QuiltLoaderAndMods" on windows
+        - "~/Library/Application Support/org.quiltmc.QuiltLoaderAndMods" on mac os
+        - "XDG_CONFIG_HOME/quilt_loader_and_mods" on linux.
+            - If XDG_CONFIG_HOME is not defined then it defaults to "~/.config"
+    - Cache directories are similar:
+        - "%LOCALAPPDATA%\QuiltMC\QuiltLoaderAndMods/Cache" on windows
+        - "~/Library/Cache/org.quiltmc.QuiltLoaderAndMods" on mac os
+        - "XDG_CACHE_HOME/quilt_loader_and_mods" on linux.
+            - If "XDG_CACHE_HOME" is not defined then it defaults to "~/.cache"
 - Added "flags" to the mod table.
     - 'o' means that a mod has had one of its dependencies changed
     - 'R' means that a mod has had one of its dependencies removed.

--- a/src/main/resources/changelog/0.19.2.txt
+++ b/src/main/resources/changelog/0.19.2.txt
@@ -5,6 +5,7 @@ Features:
     - Added a more understandable "any" / "all" object system 
     - See https://github.com/QuiltMC/rfcs/pull/56 for more details.
 - Added warnings when encountering dependency constraints that are unnecessary.
+- [#326] Added an Active User Beacon, outlined in RFC 81.
 
 Bug Fixes:
 


### PR DESCRIPTION
This implements the active user beacon ([RFC 81](https://github.com/QuiltMC/rfcs/blob/main/specification/0081-active-user-beacon.md)), also in issue #324.

This needs to have a proper link to the blog before this should be merged?

This differs slightly from the RFC: all checks are performed on the main thread (steps 1 and 2 in the RFC) and only then does it create a thread to send the request (step 3).