### PR TITLE
Memory usage improvements for transform cache

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/transformer/TransformCache.java
+++ b/src/main/java/org/quiltmc/loader/impl/transformer/TransformCache.java
@@ -148,6 +148,8 @@ public class TransformCache {
 			QuiltZipPath inner = fs.getRoot();
 			if (!FasterFiles.isRegularFile(inner.resolve(FILE_TRANSFORM_COMPLETE))) {
 				Log.info(LogCategory.CACHE, "Not reusing previous transform cache since it's incomplete!");
+				// delete the previous transform cache to prevent FileAlreadyExistsException later
+				try { Files.deleteIfExists(cacheFile); } catch(IOException ignored) {}
 				return null;
 			}
 			Path optionFile = inner.resolve("options.txt");

--- a/src/main/java/org/quiltmc/loader/impl/util/FileSystemUtil.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/FileSystemUtil.java
@@ -25,7 +25,7 @@ import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.zip.ZipError;
 
@@ -56,8 +56,17 @@ public final class FileSystemUtil {
 
 	private FileSystemUtil() { }
 
-	private static final Map<String, String> jfsArgsCreate = Collections.singletonMap("create", "true");
-	private static final Map<String, String> jfsArgsEmpty = Collections.emptyMap();
+	private static final Map<String, Object> jfsArgsCreate = new HashMap<>();
+	private static final Map<String, Object> jfsArgsEmpty = new HashMap<>();
+
+	static {
+		jfsArgsCreate.put("create", "true");
+		if(Boolean.getBoolean(SystemProperties.USE_ZIPFS_TEMP_FILE)) {
+			// must be Boolean.TRUE for Java 8
+			jfsArgsCreate.put("useTempFile", Boolean.TRUE);
+			jfsArgsEmpty.put("useTempFile", Boolean.TRUE);
+		}
+	}
 
 	public static FileSystemDelegate getJarFileSystem(Path path, boolean create) throws IOException {
 		return getJarFileSystem(path.toUri(), create);

--- a/src/main/java/org/quiltmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/SystemProperties.java
@@ -74,6 +74,8 @@ public final class SystemProperties {
 	public static final String DISABLE_OPTIMIZED_COMPRESSED_TRANSFORM_CACHE = "loader.transform_cache.disable_optimised_compression";
 	public static final String DISABLE_PRELOAD_TRANSFORM_CACHE = "loader.transform_cache.disable_preload";
 	public static final String LOG_CACHE_KEY_CHANGES = "loader.transform_cache.log_changed_keys";
+	// enable useTempFile in ZipFileSystem, reduces memory usage when writing transform cache at the cost of speed
+	public static final String USE_ZIPFS_TEMP_FILE = "loader.zipfs.use_temp_file";
 	public static final String DISABLE_BEACON = "loader.disable_beacon";
 
 	private SystemProperties() {


### PR DESCRIPTION
This PR implements some basic optimizations to the transform cache memory usage that are simple and should not break anything.

The first change involves changing the internals hider transformation logic to read the class bytes from disk twice instead of storing them in a map, thus avoiding storing all class bytes in RAM at once. I checked and this didn't seem to regress transform cache build times meaningfully compared to 0.2.0-beta.4.

I also added a new system property, `loader.zipfs.use_temp_file`, which allows bypassing the Java `ZipFileSystem` logic of storing all files being written to the ZIP in RAM. Unfortunately this introduces a fairly hefty performance penalty to building the transform cache (presumably due to all the IO going to temporary files on disk first) so it can't be enabled by default. I still think it's a worthwhile tunable to offer as it only impacts launches in which the transform cache needs to be rebuilt.

Additionally, I took the opportunity to fix an annoying bug where the transform cache cannot be recreated correctly if incomplete, due to `FileAlreadyExistsException` being thrown elsewhere in the code. I chose the simplest solution of just deleting the old incomplete file before proceeding.

This allows the BlanketCon 23 testing pack to be launched on 700MB of RAM.
