### PR TITLE
Support for pre 1.6 arguments 

### DIFF
--- a/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/applet/AppletFrame.java
+++ b/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/applet/AppletFrame.java
@@ -52,6 +52,9 @@ public class AppletFrame extends Frame implements WindowListener {
 
 		if (arguments.containsKey("session") /* 1.6 */) {
 			sessionid = arguments.get("session");
+		} else if (arguments.getExtraArgs().size() == 2 /* pre 1.6 */) {
+			username = arguments.getExtraArgs().get(0);
+			sessionid = arguments.getExtraArgs().get(1);
 		} else /* fallback */ {
 			sessionid = "";
 		}


### PR DESCRIPTION
Take a look at [the PR in fabric repository](https://github.com/FabricMC/fabric-loader/pull/632) for details.   
TLDR, this allows setting username and sessionId on versions older than 1.6 