### PR TITLE
Remap AW into `getTargetNamespace` instead of named

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/transformer/RuntimeModRemapper.java
+++ b/src/main/java/org/quiltmc/loader/impl/transformer/RuntimeModRemapper.java
@@ -132,7 +132,7 @@ final class RuntimeModRemapper {
 
 	private static byte[] remapAccessWidener(byte[] input, Remapper remapper) {
 		AccessWidenerWriter writer = new AccessWidenerWriter();
-		AccessWidenerRemapper remappingDecorator = new AccessWidenerRemapper(writer, remapper, "intermediary", "named");
+		AccessWidenerRemapper remappingDecorator = new AccessWidenerRemapper(writer, remapper, "intermediary", QuiltLauncherBase.getLauncher().getTargetNamespace());
 		AccessWidenerReader accessWidenerReader = new AccessWidenerReader(remappingDecorator);
 		accessWidenerReader.read(input, "intermediary");
 		return writer.write();


### PR DESCRIPTION
Since [L69](https://github.com/QuiltMC/quilt-loader/blob/develop/src/main/java/org/quiltmc/loader/impl/transformer/RuntimeModRemapper.java#L69) is `getTargetNamespace`, [L135](https://github.com/PillowMC/quilt-loader/blob/develop/src/main/java/org/quiltmc/loader/impl/transformer/RuntimeModRemapper.java#L135) should also be `getTargetNamespace`.