### PR TITLE
Add support for 1.20.3 snapshots

### DIFF
--- a/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/McVersionLookup.java
+++ b/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/McVersionLookup.java
@@ -284,7 +284,9 @@ public final class McVersionLookup {
 			int year = Integer.parseInt(matcher.group(1));
 			int week = Integer.parseInt(matcher.group(2));
 
-			if (year >= 23 && week >= 31) {
+			if (year >= 23 && week >= 40) {
+				return "1.20.3";
+			} else if (year >= 23 && week >= 31 && week <= 35) {
 				return "1.20.2";
 			} else if (year == 23 && week >= 12 && week <= 18) {
 				return "1.20";


### PR DESCRIPTION
Fixes current snapshots still being read as `1.20.2-alpha.xx.xx.x`.