### PR TITLE
Update to fabric loader 0.14.24

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ url = https://github.com/quiltmc/quilt-loader
 quilt_loader = 0.21.2-beta.3
 
 # Fabric & Quilt Libraries
-asm = 9.5
+asm = 9.6
 sponge_mixin = 0.12.5+mixin.0.8.5
 tiny_mappings_parser = 0.3.0+build.17
 tiny_remapper = 0.8.6

--- a/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/MinecraftGameProvider.java
+++ b/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/MinecraftGameProvider.java
@@ -48,6 +48,7 @@ import org.quiltmc.loader.impl.game.GameProviderHelper;
 import org.quiltmc.loader.impl.game.LibClassifier;
 import org.quiltmc.loader.impl.game.minecraft.patch.BrandingPatch;
 import org.quiltmc.loader.impl.game.minecraft.patch.EntrypointPatch;
+import org.quiltmc.loader.impl.game.minecraft.patch.TinyFDPatch;
 import org.quiltmc.loader.impl.launch.common.QuiltLauncher;
 import org.quiltmc.loader.impl.metadata.qmj.V1ModMetadataBuilder;
 import org.quiltmc.loader.impl.util.Arguments;
@@ -92,7 +93,8 @@ public class MinecraftGameProvider implements GameProvider {
 
 	private final GameTransformer transformer = new GameTransformer(
 			new EntrypointPatch(this),
-			new BrandingPatch());
+			new BrandingPatch(),
+			new TinyFDPatch());
 
 	@Override
 	public String getGameId() {

--- a/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/patch/TinyFDPatch.java
+++ b/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/patch/TinyFDPatch.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.loader.impl.game.minecraft.patch;
+
+import java.util.ListIterator;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.LdcInsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.quiltmc.loader.api.QuiltLoader;
+import org.quiltmc.loader.impl.entrypoint.GamePatch;
+import org.quiltmc.loader.impl.entrypoint.GamePatchContext;
+import org.quiltmc.loader.impl.launch.common.QuiltLauncher;
+
+import net.fabricmc.api.EnvType;
+
+/**
+ * Patch the TinyFileDialogs.tinyfd_openFileDialog call to use a trusted string in MoreOptionsDialog.
+ *
+ * <p>This patch applies to Minecraft versions 20w21a -> 23w04a inclusive
+ */
+public final class TinyFDPatch extends GamePatch {
+	private static final String MORE_OPTIONS_DIALOG_CLASS_NAME = "net.minecraft.class_5292";
+	private static final String TINYFD_METHOD_NAME = "tinyfd_openFileDialog";
+	// This is the en_us value of selectWorld.import_worldgen_settings.select_file
+	private static final String DIALOG_TITLE = "Select settings file (.json)";
+
+	@Override
+	public void process(QuiltLauncher launcher, GamePatchContext context) {
+		if (launcher.getEnvironmentType() != EnvType.CLIENT) {
+			// Fix should only be applied to clients.
+			return;
+		}
+
+		String className = MORE_OPTIONS_DIALOG_CLASS_NAME;
+
+		// Only remap the classname when needed to prevent loading the mappings when not required in prod.
+		if (!launcher.getMappingConfiguration().getTargetNamespace().equals("intermediary")
+				&& QuiltLoader.getMappingResolver().getNamespaces().contains("intermediary")) {
+			className = QuiltLoader.getMappingResolver().mapClassName("intermediary", MORE_OPTIONS_DIALOG_CLASS_NAME);
+		}
+
+		final ClassNode classNode = context.getClassNode(className);
+
+		if (classNode == null) {
+			// Class is not present in this version, nothing to do.
+			return;
+		}
+
+		patchMoreOptionsDialog(classNode);
+		context.addPatchedClass(classNode);
+	}
+
+	private void patchMoreOptionsDialog(ClassNode classNode) {
+		for (MethodNode method : classNode.methods) {
+			final ListIterator<AbstractInsnNode> iterator = findTargetMethodNode(method);
+
+			if (iterator == null) {
+				continue;
+			}
+
+			while (iterator.hasPrevious()) {
+				final AbstractInsnNode insnNode = iterator.previous();
+
+				// Find the Text.getString() instruction
+				// or find the TranslatableText.getString() instruction present in older versions (e.g 1.16.5)
+				if (insnNode.getOpcode() == Opcodes.INVOKEINTERFACE
+						|| insnNode.getOpcode() == Opcodes.INVOKEVIRTUAL) {
+					InsnList insnList = new InsnList();
+					// Drop the possibly malicious value
+					insnList.add(new InsnNode(Opcodes.POP));
+					// And replace it with something we trust
+					insnList.add(new LdcInsnNode(DIALOG_TITLE));
+
+					method.instructions.insert(insnNode, insnList);
+					return;
+				}
+			}
+
+			throw new IllegalStateException("Failed to patch MoreOptionsDialog");
+		}
+
+		// At this point we failed to find a valid target method.
+		// 20w20a and 20w20b have the class but do not use tinyfd
+	}
+
+	private ListIterator<AbstractInsnNode> findTargetMethodNode(MethodNode methodNode) {
+		if ((methodNode.access & Opcodes.ACC_SYNTHETIC) == 0) {
+			// We know it's in a synthetic method
+			return null;
+		}
+
+		// Visit all the instructions until we find the TinyFileDialogs.tinyfd_openFileDialog call
+		ListIterator<AbstractInsnNode> iterator = methodNode.instructions.iterator();
+
+		while (iterator.hasNext()) {
+			final AbstractInsnNode instruction = iterator.next();
+
+			if (instruction.getOpcode() != Opcodes.INVOKESTATIC) {
+				continue;
+			}
+
+			if (!(instruction instanceof MethodInsnNode)) {
+				continue;
+			}
+
+			final MethodInsnNode methodInsnNode = (MethodInsnNode) instruction;
+
+			if (methodInsnNode.name.equals(TINYFD_METHOD_NAME)) {
+				return iterator;
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/fabric/api/java/net/fabricmc/loader/api/FabricLoader.java
+++ b/src/fabric/api/java/net/fabricmc/loader/api/FabricLoader.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
@@ -100,6 +101,22 @@ public interface FabricLoader {
 	 * @see LanguageAdapter
 	 */
 	<T> List<EntrypointContainer<T>> getEntrypointContainers(String key, Class<T> type);
+
+	/**
+	 * Invokes an action on all entrypoints that would be returned by {@link #getEntrypointContainers(String, Class)} for the given
+	 * <code>key</code> and <code>type</code>.
+	 *
+	 * <p>The action is invoked by applying the given <code>invoker</code> to each entrypoint instance.
+	 *
+	 * <p>Exceptions thrown by <code>invoker</code> will be collected and thrown after all entrypoints have been invoked.
+	 *
+	 * @param key     the key in entrypoint declaration in {@code fabric.mod.json}
+	 * @param type    the type of entrypoints
+	 * @param invoker applied to each entrypoint to invoke the desired action
+	 * @param <T>     the type of entrypoints
+	 * @see #getEntrypointContainers(String, Class)
+	 */
+	<T> void invokeEntrypoints(String key, Class<T> type, Consumer<? super T> invoker);
 
 	/**
 	 * Get the object share for inter-mod communication.

--- a/src/fabric/impl/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
+++ b/src/fabric/impl/java/net/fabricmc/loader/impl/FabricLoaderImpl.java
@@ -29,6 +29,7 @@ import net.fabricmc.loader.impl.entrypoint.EntrypointContainerImpl;
 import org.jetbrains.annotations.Nullable;
 import org.quiltmc.loader.api.QuiltLoader;
 import org.quiltmc.loader.api.entrypoint.EntrypointException;
+import org.quiltmc.loader.api.entrypoint.EntrypointUtil;
 import org.quiltmc.loader.api.minecraft.MinecraftQuiltLoader;
 
 import java.io.File;
@@ -38,6 +39,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 @Deprecated
 public class FabricLoaderImpl extends FabricLoader {
@@ -62,6 +64,11 @@ public class FabricLoaderImpl extends FabricLoader {
 		} catch (EntrypointException e) {
 			throw new net.fabricmc.loader.api.EntrypointException(e.getKey(), e);
 		}
+	}
+
+	@Override
+	public <T> void invokeEntrypoints(String key, Class<T> type, Consumer<? super T> invoker) {
+		EntrypointUtil.invoke(key, type, invoker);
 	}
 
 	@Override

--- a/src/main/resources/changelog/0.21.2.txt
+++ b/src/main/resources/changelog/0.21.2.txt
@@ -11,3 +11,17 @@ Bug FIxes:
 - [#377] Added overlap detection to GamePatch.process, which fixes a 1.2.5 server not launching with quilt loader (#376).
 - [#375] Fix "guarenteed" typo instead of "guaranteed" (ix0rai)
 - [#371] Fix access widener remapping using the constant "named" instead of fetching the target namespace (heipiao233)
+
+Changes from upstream (fabric-loader 0.14.23 and 0.14.24)
+
+- Updated to ASM 9.6
+- Added FabricLoader.invokeEntrypoints
+- Fix a command injection vulnerability in vanilla Minecraft 20w21a -> 23w04a.
+
+    Changelog from fabric:
+
+    Fix a command injection vulnerability allowing malicious resource pack to unexpectedly execute code on Linux clients running vanilla Minecraft 1.16 (20w21a) -> 1.19.3 (23w04a).
+    It was recently found that the Tiny File Dialogs library is vulnerable to command injection techniques on Linux when invoked with untrusted data. This fix makes a small change in the create world `MoreOptionsDialog` screen to pass a hardcoded string as the dialog title.
+    Many thanks to ThatGravyBoat and Moulberry for investigating this issue and reporting it to fabric in confidence.
+
+(Fix originally committed by modmuss50 here: https://github.com/FabricMC/fabric-loader/commit/5d10144502f403a0c1356418821bc74b1c350436 )

--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -22,7 +22,7 @@
     "provides": [
       {
         "id": "fabricloader",
-        "version": "0.14.22"
+        "version": "0.14.24"
       }
     ]
   }


### PR DESCRIPTION
This brings in three changes:

- Updated to ASM 9.6
- Added FabricLoader.invokeEntrypoints
- Fix a command injection vulnerability in vanilla Minecraft 20w21a -> 23w04a.

Which are only 3 commits of the actual upstream changeset: https://github.com/FabricMC/fabric-loader/compare/0.14.22...0.14.24