### PR TITLE
Print the break reason on error

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/plugin/SolverErrorHelper.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/SolverErrorHelper.java
@@ -810,7 +810,7 @@ class SolverErrorHelper {
 			}
 
 			for (ModLoadOption mod : from) {
-				error.appendReportText("- " + manager.describePath(mod.from()), "");
+				error.appendReportText("- " + manager.describePath(mod.from()));
 			}
 		}
 	}

--- a/src/main/java/org/quiltmc/loader/impl/plugin/SolverErrorHelper.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/SolverErrorHelper.java
@@ -806,7 +806,7 @@ class SolverErrorHelper {
 			error.appendReportText(report.toString(), "");
 
 			if (!reason.isEmpty()) {
-				error.appendReportText("Reason: " + reason, "");
+				error.appendReportText("Breaking mod's reason: " + reason, "");
 			}
 
 			for (ModLoadOption mod : from) {

--- a/src/main/java/org/quiltmc/loader/impl/plugin/SolverErrorHelper.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/SolverErrorHelper.java
@@ -553,7 +553,8 @@ class SolverErrorHelper {
 		ModLoadOption from = modC.option;
 		Set<ModLoadOption> allBreakingOptions = new LinkedHashSet<>();
 		allBreakingOptions.addAll(ruleE.getConflictingOptions());
-		this.errors.add(new BreakageError(modOn, versionsOn, from, allBreakingOptions));
+		String reason = ruleE.publicDep.reason();
+		this.errors.add(new BreakageError(modOn, versionsOn, from, allBreakingOptions, reason));
 
 		return true;
 	}
@@ -708,13 +709,15 @@ class SolverErrorHelper {
 		final VersionRange versionsOn;
 		final Set<ModLoadOption> from = new LinkedHashSet<>();
 		final Set<ModLoadOption> allBreakingOptions;
+		final String reason;
 
 		BreakageError(ModDependencyIdentifier modOn, VersionRange versionsOn, ModLoadOption from, Set<
-			ModLoadOption> allBreakingOptions) {
+			ModLoadOption> allBreakingOptions, String reason) {
 			this.modOn = modOn;
 			this.versionsOn = versionsOn;
 			this.from.add(from);
 			this.allBreakingOptions = allBreakingOptions;
+			this.reason = reason;
 		}
 
 		@Override
@@ -761,6 +764,11 @@ class SolverErrorHelper {
 
 			setIconFromMod(manager, mandatoryMod, error);
 
+			if (!reason.isEmpty()) {
+				error.appendDescription(QuiltLoaderText.translate("error.reason", reason));
+				// A newline after the reason was desired here, but do you think Swing loves nice things?
+			}
+
 			Map<Path, ModLoadOption> realPaths = new LinkedHashMap<>();
 
 			for (ModLoadOption mod : from) {
@@ -797,8 +805,12 @@ class SolverErrorHelper {
 			report.append(", which is present!");
 			error.appendReportText(report.toString(), "");
 
+			if (!reason.isEmpty()) {
+				error.appendReportText("Reason: " + reason, "");
+			}
+
 			for (ModLoadOption mod : from) {
-				error.appendReportText("- " + manager.describePath(mod.from()));
+				error.appendReportText("- " + manager.describePath(mod.from()), "");
 			}
 		}
 	}

--- a/src/main/resources/lang/quilt_loader.properties
+++ b/src/main/resources/lang/quilt_loader.properties
@@ -147,6 +147,7 @@ error.arg_mods.missing.by.desc=It is specified by %s (inside %s), and must be pr
 error.arg_mods.not_folder.title=Specified a folder, but %s is a file!
 error.arg_mods.not_folder.desc=Cannot scan a file for sub-mods.\nIt is specified by %s, and must be present.\nFull path: %s
 error.arg_mods.not_folder.by.desc=Cannot scan a file for sub-mods.\nIt is specified by %s (inside %s), and must be present.\nFull path: %s
+error.reason=Reason: %s
 
 # Solver Rules
 solver.rule.mod_def.mandatory=Mandatory Mod '%s', version '%s', loaded from %s

--- a/src/main/resources/lang/quilt_loader.properties
+++ b/src/main/resources/lang/quilt_loader.properties
@@ -147,7 +147,7 @@ error.arg_mods.missing.by.desc=It is specified by %s (inside %s), and must be pr
 error.arg_mods.not_folder.title=Specified a folder, but %s is a file!
 error.arg_mods.not_folder.desc=Cannot scan a file for sub-mods.\nIt is specified by %s, and must be present.\nFull path: %s
 error.arg_mods.not_folder.by.desc=Cannot scan a file for sub-mods.\nIt is specified by %s (inside %s), and must be present.\nFull path: %s
-error.reason=Reason: %s
+error.reason=Breaking mod's reason: %s
 
 # Solver Rules
 solver.rule.mod_def.mandatory=Mandatory Mod '%s', version '%s', loaded from %s


### PR DESCRIPTION
Oh god I can't believe that `reason` was useless all this time;
This PR makes `reason` useful for `break`s:
(Note: "Reason" has been changed to "Breaking mod's reason")
![image](https://github.com/QuiltMC/quilt-loader/assets/85590273/aa1cee11-929e-453f-bd41-a9557aff3603)