### PR TITLE
Publish dependencies as seperate module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,13 @@ plugins {
 	id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+java {
+	toolchain {
+		languageVersion.set(JavaLanguageVersion.of(8))
+	}
+	withJavadocJar()
+	withSourcesJar()
+}
 
 archivesBaseName = "quilt-loader"
 version = project.quilt_loader
@@ -59,11 +64,6 @@ allprojects {
 			}
 		}
 	}
-	java {
-		toolchain {
-			languageVersion = JavaLanguageVersion.of(17)
-		}
-	}
 }
 
 sourceSets {
@@ -77,48 +77,25 @@ configurations {
 	   transitive = false
 	}
 
-	implementation {
-		extendsFrom include
-	}
+	development
 
-	development {
-		transitive = false
-	}
-
-	api {
-		extendsFrom development
-	}
+	compileClasspath.extendsFrom localImplementation
+	runtimeClasspath.extendsFrom localImplementation
+	localImplementation.extendsFrom include
 }
 
 dependencies {
-	// Non-"include"d dependencies must be added to the LoaderLibrary class as well.
-	api "org.ow2.asm:asm:${project.asm}"
-	api "org.ow2.asm:asm-analysis:${project.asm}"
-	api "org.ow2.asm:asm-commons:${project.asm}"
-	api "org.ow2.asm:asm-tree:${project.asm}"
-	api "org.ow2.asm:asm-util:${project.asm}"
-
-	api("net.fabricmc:sponge-mixin:${project.sponge_mixin}") {
-		exclude module: 'launchwrapper'
-		exclude module: 'guava'
-	}
-	api "net.fabricmc:tiny-mappings-parser:${project.tiny_mappings_parser}"
-	api "net.fabricmc:tiny-remapper:${project.tiny_remapper}"
-	api "net.fabricmc:access-widener:${project.access_widener}"
-
-	/*include*/ api "org.quiltmc:quilt-json5:${project.quilt_json5}"
 	include "org.quiltmc:quilt-loader-sat4j:${project.quilt_loader_sat4j}"
 
 	include "org.quiltmc.quilt-config.serializers:toml:${project.quilt_config}"
 	include "org.quiltmc.quilt-config.serializers:json5:${project.quilt_config}"
-	api "org.quiltmc:quilt-config:${project.quilt_config}"
 
 	include "com.electronwill.night-config:core:${project.night_config}"
 	include "com.electronwill.night-config:toml:${project.night_config}"
 	shadow "com.electronwill.night-config:core:${project.night_config}"
 	shadow "com.electronwill.night-config:toml:${project.night_config}"
 
-	development "io.github.llamalad7:mixinextras-fabric:$mixin_extras"
+	development project(path: ':dependencies', configuration: 'development')
 
 	// also must update in minecraft AND minecraft test
 	compileOnly "org.quiltmc.chasm:chasm:${project.quilt_chasm}"
@@ -136,6 +113,13 @@ dependencies {
 	// Unit testing
 	testImplementation(platform("org.junit:junit-bom:${project.junit_bom}"))
 	testImplementation("org.junit.jupiter:junit-jupiter")
+
+	/*api*/ localImplementation project(':dependencies')
+}
+
+def javaComponent = components.java as AdhocComponentWithVariants
+javaComponent.withVariantsFromConfiguration(configurations.shadowRuntimeElements) {
+	skip()
 }
 
 test {
@@ -177,17 +161,6 @@ processResources {
 			"mixin_extras": project.mixin_extras,
 		)
 	}
-}
-
-java {
-	sourceCompatibility = 8
-	targetCompatibility = 8
-	withJavadocJar()
-	withSourcesJar()
-}
-
-compileJava {
-	options.release.set(8)
 }
 
 jar {
@@ -305,8 +278,6 @@ task testJar(type: Jar) {
 	from sourceSets.test.output
 }
 
-
-
 task copyJson() {
 	def inJson = file('build/resources/main/quilt_installer.json')
 	//def inLwJson = file('src/main/resources/fabric-installer.launchwrapper.json')
@@ -327,14 +298,13 @@ tasks.build.dependsOn "copyJson"
 
 tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"
-
-	// Target JDK 8
-	if (JavaVersion.current().isJava9Compatible()) {
-		it.options.release.set(8)
-	}
 }
 
 javadoc {
+	javadocTool.set javaToolchains.javadocToolFor {
+		languageVersion = JavaLanguageVersion.of(17)
+	}
+
 	options {
 		if (file("README.html").exists()) {
 			overview = "README.html"
@@ -381,18 +351,23 @@ allprojects {
 
 // Causes more trouble than its worth
 tasks.withType(GenerateModuleMetadata) {
-	enabled = false
+	//enabled = false
+}
+
+['runtimeElements', 'apiElements'].each { configuration ->
+	configurations[configuration].outgoing.artifacts.clear()
+	artifacts {
+		add(configuration, proguardFile) {
+			builtBy proguardJar
+		}
+	}
 }
 
 publishing {
 	publications {
 		mavenJava(MavenPublication) {
 			// add all the jars that should be included when publishing to maven
-			artifact(proguardFile) {
-				builtBy proguardJar
-			}
-			artifact(sourcesJar)
-			artifact javadocJar
+			from components.java
 			artifact(file('build/resources/main/quilt_installer.json')) {
 				builtBy processResources
 				builtBy copyJson
@@ -400,42 +375,6 @@ publishing {
 //			artifact(file('src/main/resources/fabric-installer.launchwrapper.json')) {
 //				builtBy copyJson
 //				classifier = "launchwrapper"
-//			}
-
-			// Manually inject the dependencies into the final POM.
-			// This allows for use without Loom in projects that don't need it.
-			//
-			// This is done this way to avoid including dependencies that are
-			// shaded in, as Gradle seems to provide no clean way of excluding
-			// dependencies from the final POM.
-			//
-			// Note: This only uses the `api` configuration to determine what is
-			// fine to include, and does not respect exclusions. A more advanced
-			// implementation that excludes the `include` configuration from
-			// runtime & compile classpaths would likely prove to be better if
-			// Quilt ever needs to have dependencies that aren't to be shaded nor
-			// passed through to the application.
-			// TODO: disabled until Loom can properly handle this.
-//			pom.withXml {
-//				final def dependenciesNode = asNode().appendNode("dependencies")
-//
-//				for (final def dep : configurations.api.allDependencies) {
-//					// Tests for an external dependency.
-//					// Provides a guarantee that the needed metadata is present.
-//					if (dep instanceof ExternalDependency) {
-//						// Inject the dependency metadata.
-//						final def dependencyNode = dependenciesNode.appendNode("dependency")
-//
-//						dependencyNode.appendNode("groupId", dep.group)
-//						dependencyNode.appendNode("artifactId", dep.name)
-//						dependencyNode.appendNode("version", dep.version)
-//
-//						// Note: If ever retrofitted to include the runtime classpath,
-//						// change this to use the runtime scope if the dependency is not
-//						// present in the compile classpath.
-//						dependencyNode.appendNode("scope", "compile")
-//					}
-//				}
 //			}
 		}
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -73,40 +73,22 @@ sourceSets {
 }
 
 configurations {
-	include {
-	   transitive = false
-	}
-
+	include
 	development
 
 	compileClasspath.extendsFrom localImplementation
 	runtimeClasspath.extendsFrom localImplementation
+	testImplementation.extendsFrom localImplementation
 	localImplementation.extendsFrom include
 }
 
 dependencies {
-	include "org.quiltmc:quilt-loader-sat4j:${project.quilt_loader_sat4j}"
-
-	include "org.quiltmc.quilt-config.serializers:toml:${project.quilt_config}"
-	include "org.quiltmc.quilt-config.serializers:json5:${project.quilt_config}"
-
-	include "com.electronwill.night-config:core:${project.night_config}"
-	include "com.electronwill.night-config:toml:${project.night_config}"
-	shadow "com.electronwill.night-config:core:${project.night_config}"
-	shadow "com.electronwill.night-config:toml:${project.night_config}"
-
+	include project(path: ':dependencies', configuration: 'include')
 	development project(path: ':dependencies', configuration: 'development')
 
 	// also must update in minecraft AND minecraft test
 	compileOnly "org.quiltmc.chasm:chasm:${project.quilt_chasm}"
 	compileOnly "org.quiltmc.chasm:chassembly:${project.quilt_chasm}"
-
-	shadow "org.quiltmc.quilt-config.serializers:toml:${project.quilt_config}"
-	shadow "org.quiltmc.quilt-config.serializers:json5:${project.quilt_config}"
-	shadow "org.quiltmc.parsers:json:${project.quilt_parsers}"
-	include "org.quiltmc.parsers:json:${project.quilt_parsers}"
-	include "com.unascribed:flexver-java:${project.flexver}"
-	shadow "com.unascribed:flexver-java:${project.flexver}"
 
 	testCompileOnly "org.jetbrains:annotations:${project.annotations}"
 
@@ -349,15 +331,10 @@ allprojects {
 	}
 }
 
-// Causes more trouble than its worth
-tasks.withType(GenerateModuleMetadata) {
-	//enabled = false
-}
-
-['runtimeElements', 'apiElements'].each { configuration ->
-	configurations[configuration].outgoing.artifacts.clear()
+[configurations.runtimeElements, configurations.apiElements].each { configuration ->
+	configuration.outgoing.artifacts.clear()
 	artifacts {
-		add(configuration, proguardFile) {
+		add(configuration.name, proguardFile) {
 			builtBy proguardJar
 		}
 	}

--- a/dependencies/build.gradle
+++ b/dependencies/build.gradle
@@ -1,0 +1,92 @@
+plugins {
+	id 'maven-publish'
+	id 'java'
+}
+
+base.archivesName.set 'quilt-loader-dependencies'
+version = rootProject.version
+group = rootProject.group
+
+java {
+	toolchain {
+		languageVersion.set(JavaLanguageVersion.of(8))
+	}
+}
+
+def ENV = System.getenv()
+
+configurations {
+	development {
+		transitive = false
+		canBeConsumed = true
+	}
+
+	published {
+		extendsFrom development
+	}
+
+	runtimeElements {
+		extendsFrom published
+		outgoing.artifacts.clear()
+		outgoing.variants.clear()
+	}
+	apiElements {
+		extendsFrom published
+		outgoing.artifacts.clear()
+		outgoing.variants.clear()
+	}
+}
+
+dependencies {
+	// Non-"include"d dependencies must be added to the LoaderLibrary class as well.
+	published "org.ow2.asm:asm:${project.asm}"
+	published "org.ow2.asm:asm-analysis:${project.asm}"
+	published "org.ow2.asm:asm-commons:${project.asm}"
+	published "org.ow2.asm:asm-tree:${project.asm}"
+	published "org.ow2.asm:asm-util:${project.asm}"
+
+	published("net.fabricmc:sponge-mixin:${project.sponge_mixin}") {
+		exclude module: 'launchwrapper'
+		exclude module: 'guava'
+	}
+	published "net.fabricmc:tiny-mappings-parser:${project.tiny_mappings_parser}"
+	published "net.fabricmc:tiny-remapper:${project.tiny_remapper}"
+	published "net.fabricmc:access-widener:${project.access_widener}"
+
+	/*include*/ published "org.quiltmc:quilt-json5:${project.quilt_json5}"
+	published "org.quiltmc:quilt-config:${project.quilt_config}"
+
+	development "io.github.llamalad7:mixinextras-fabric:$mixin_extras"
+}
+
+publishing {
+	publications {
+		maven(MavenPublication) {
+			artifactId project.archivesBaseName
+			from components.java
+		}
+	}
+
+	repositories {
+		if (ENV.MAVEN_URL) {
+			maven {
+				url ENV.MAVEN_URL
+				credentials {
+					username ENV.MAVEN_USERNAME
+					password ENV.MAVEN_PASSWORD
+				}
+			}
+		} else if (ENV.SNAPSHOTS_URL) {
+			maven {
+				url ENV.SNAPSHOTS_URL
+
+				credentials {
+					username ENV.SNAPSHOTS_USERNAME
+					password ENV.SNAPSHOTS_PASSWORD
+				}
+			}
+		} else {
+			mavenLocal()
+		}
+	}
+}

--- a/dependencies/build.gradle
+++ b/dependencies/build.gradle
@@ -35,6 +35,16 @@ configurations {
 		outgoing.artifacts.clear()
 		outgoing.variants.clear()
 	}
+
+	include {
+		transitive = false
+	}
+}
+
+[configurations.runtimeElements, configurations.apiElements].each {
+	// included in quilt loader and not relocated
+	it.exclude(group: 'org.quiltmc.quilt-config.serializers', module: 'toml')
+	it.exclude(group: 'org.quiltmc.quilt-config.serializers', module: 'json5')
 }
 
 dependencies {
@@ -57,6 +67,17 @@ dependencies {
 	published "org.quiltmc:quilt-config:${project.quilt_config}"
 
 	development "io.github.llamalad7:mixinextras-fabric:$mixin_extras"
+
+	include "org.quiltmc:quilt-loader-sat4j:${project.quilt_loader_sat4j}"
+
+	include "org.quiltmc.quilt-config.serializers:toml:${project.quilt_config}"
+	include "org.quiltmc.quilt-config.serializers:json5:${project.quilt_config}"
+
+	include "com.electronwill.night-config:core:${project.night_config}"
+	include "com.electronwill.night-config:toml:${project.night_config}"
+
+	include "org.quiltmc.parsers:json:${project.quilt_parsers}"
+	include "com.unascribed:flexver-java:${project.flexver}"
 }
 
 publishing {

--- a/junit/build.gradle
+++ b/junit/build.gradle
@@ -22,11 +22,13 @@ repositories {
 configurations {
 	compileClasspath.extendsFrom localImplementation
 	runtimeClasspath.extendsFrom localImplementation
+	testImplementation.extendsFrom localImplementation
 }
 
 dependencies {
 	api project(":")
 	localImplementation project(':dependencies')
+	localImplementation project(path: ':dependencies', configuration: 'include')
 
 	api platform("org.junit:junit-bom:5.9.2")
 	api "org.junit.jupiter:junit-jupiter-engine"

--- a/junit/build.gradle
+++ b/junit/build.gradle
@@ -2,24 +2,31 @@ plugins {
 	id("maven-publish")
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+java {
+	toolchain {
+		languageVersion.set(JavaLanguageVersion.of(8))
+	}
+	withSourcesJar()
+}
 
 archivesBaseName = "quilt-loader-junit"
 version = rootProject.version
 group = rootProject.group
 
 def ENV = System.getenv()
-compileJava {
-	options.release.set(8)
-}
 
 repositories {
 	mavenCentral()
 }
 
+configurations {
+	compileClasspath.extendsFrom localImplementation
+	runtimeClasspath.extendsFrom localImplementation
+}
+
 dependencies {
 	api project(":")
+	localImplementation project(':dependencies')
 
 	api platform("org.junit:junit-bom:5.9.2")
 	api "org.junit.jupiter:junit-jupiter-engine"
@@ -30,16 +37,8 @@ dependencies {
 	compileOnly "org.quiltmc.chasm:chasm:${project.quilt_chasm}"
 }
 
-java {
-	withSourcesJar()
-}
-
 tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"
-
-	if (JavaVersion.current().isJava9Compatible()) {
-		it.options.release = 8
-	}
 }
 
 publishing {

--- a/minecraft-test/build.gradle
+++ b/minecraft-test/build.gradle
@@ -6,8 +6,12 @@ plugins {
 	id("fabric-loom") version "0.10-SNAPSHOT"
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+	toolchain {
+		languageVersion.set(JavaLanguageVersion.of(8))
+	}
+}
+
 repositories {
 	maven {
 		url = "https://maven.quiltmc.org/repository/release"
@@ -39,13 +43,6 @@ processResources {
 
 tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"
-
-	// The Minecraft launcher currently installs Java 8 for users, so your mod probably wants to target Java 8 too
-	// JDK 9 introduced a new way of specifying this that will make sure no newer classes or methods are used.
-	// We'll use that if it's available, but otherwise we'll use the older option.
-	if (JavaVersion.current().isJava9Compatible()) {
-		it.options.release = 8
-	}
 }
 
 spotless {

--- a/minecraft/build.gradle
+++ b/minecraft/build.gradle
@@ -11,16 +11,10 @@ repositories {
 	}
 }
 
-configurations {
-	compileClasspath.extendsFrom localImplementation
-	runtimeClasspath.extendsFrom localImplementation
-}
-
 dependencies {
-	api project(":")
-	localImplementation project(':dependencies')
-
-	implementation project(":").sourceSets.main.output
+	implementation project(':dependencies')
+	implementation project(path: ':dependencies', configuration: 'include')
+	implementation project(":")
 	// log4j wrapper
 	compileOnly 'org.apache.logging.log4j:log4j-api:2.8.1'
 	// slf4j wrapper

--- a/minecraft/build.gradle
+++ b/minecraft/build.gradle
@@ -1,8 +1,7 @@
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-compileJava {
-	options.release.set(8)
+java {
+	toolchain {
+		languageVersion.set(JavaLanguageVersion.of(8))
+	}
 }
 
 repositories {
@@ -12,8 +11,15 @@ repositories {
 	}
 }
 
+configurations {
+	compileClasspath.extendsFrom localImplementation
+	runtimeClasspath.extendsFrom localImplementation
+}
+
 dependencies {
 	api project(":")
+	localImplementation project(':dependencies')
+
 	implementation project(":").sourceSets.main.output
 	// log4j wrapper
 	compileOnly 'org.apache.logging.log4j:log4j-api:2.8.1'
@@ -39,10 +45,6 @@ sourceSets {
 
 tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"
-
-	if (JavaVersion.current().isJava9Compatible()) {
-		it.options.release = 8
-	}
 }
 
 jar {

--- a/minecraft/minecraft-test/build.gradle
+++ b/minecraft/minecraft-test/build.gradle
@@ -18,10 +18,9 @@ dependencies {
 	minecraft "com.mojang:minecraft:1.20.2"
 	mappings "org.quiltmc:quilt-mappings:1.20.2+build.1:intermediary-v2"
 
-
 	implementation project(":minecraft")
-	implementation project(":minecraft").sourceSets.main.output
-	implementation project(":")
+	implementation project(":dependencies")
+	implementation project(path: ":dependencies", configuration: "include")
 	implementation project(":").sourceSets.main.output
 	// so that it works on runtime
 	implementation "org.quiltmc.chasm:chassembly:${project.quilt_chasm}"

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,9 @@ pluginManagement {
 	}
 }
 
+plugins {
+	id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+}
 
 rootProject.name = "quilt-loader"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,3 +19,4 @@ rootProject.name = "quilt-loader"
 include "minecraft"
 include "minecraft:minecraft-test"
 include 'junit'
+include 'dependencies'


### PR DESCRIPTION
Sets up publishing of loader's dependencies in a loom-friendly fashion. As I had to touch a few different parts of the buildscript while doing this, I took the occasion to switch to using toolchains to handle the java version used for compiling and generating javadoc.

The dependencies are publishes as a module at `org.quiltmc:quilt-loader-dependencies`; currently, loader itself does not publish a dependency on this module, though this would be changed once an accompanying exclusion has been added to quilt loom, backported to old versions, and some time given for people to update