### PR TITLE
Changed Icons class to be public

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/Icons.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/Icons.java
@@ -40,7 +40,7 @@ public interface Icons {
 		@Nullable
 		private final String icon;
 
-		Single(@Nullable String icon) {
+		public Single(@Nullable String icon) {
 			this.icon = icon;
 		}
 
@@ -57,7 +57,7 @@ public interface Icons {
 	public final class Multiple implements Icons {
 		private final SortedMap<Integer, String> icons;
 
-		Multiple(SortedMap<Integer, String> icons) {
+		public Multiple(SortedMap<Integer, String> icons) {
 			this.icons = icons;
 		}
 

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/Icons.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/Icons.java
@@ -26,7 +26,7 @@ import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
  * Implementation of an icon lookup.
  */
 @QuiltLoaderInternal(QuiltLoaderInternalType.LEGACY_EXPOSED)
-interface Icons {
+public interface Icons {
 	/**
 	 * @see org.quiltmc.loader.api.ModMetadata#icon(int)
 	 */
@@ -36,7 +36,7 @@ interface Icons {
 	/**
 	 * Implementation for a mod.
 	 */
-	final class Single implements Icons {
+	public final class Single implements Icons {
 		@Nullable
 		private final String icon;
 
@@ -54,7 +54,7 @@ interface Icons {
 	/**
 	 * Implementation for a mod which has multiple icons of different sizes.
 	 */
-	final class Multiple implements Icons {
+	public final class Multiple implements Icons {
 		private final SortedMap<Integer, String> icons;
 
 		Multiple(SortedMap<Integer, String> icons) {


### PR DESCRIPTION
Currently, there is no way to set the [V1ModMetadataBuilder](https://github.com/QuiltMC/quilt-loader/blob/56a4df3a0dc624965596a6003e277230ee0f78bc/src/main/java/org/quiltmc/loader/impl/metadata/qmj/V1ModMetadataBuilder.java#L57)'s icon due to the Icons class being private. This PR just turns it public so that it can be used by external mods who need a way to set their icons.