### PR TITLE
Fix Fabric mod author and contributor potentially duplicating mod contributors

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/FabricModMetadataWrapper.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/FabricModMetadataWrapper.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -226,18 +227,26 @@ public class FabricModMetadataWrapper implements InternalModMetadata {
 		return Collections.unmodifiableList(Arrays.asList(out.toArray(new ModDependency[0])));
 	}
 
+	private static void addRoleToContributor(Map<String, List<String>> contributors, String name, String role) {
+		contributors.computeIfAbsent(name, unused -> new ArrayList<>()).add(role);
+	}
+
 	private static Collection<ModContributor> convertContributors(FabricLoaderModMetadata metadata) {
-		List<ModContributor> contributors = new ArrayList<>();
+		Map<String, List<String>> contributorRoles = new LinkedHashMap<>();
+
 		for (Person author : metadata.getAuthors()) {
-			List<String> roles = new ArrayList<>();
-			roles.add("Author");
-			contributors.add(new ModContributorImpl(author.getName(), roles));
+			addRoleToContributor(contributorRoles, author.getName(), "Author");
 		}
 		for (Person contributor : metadata.getContributors()) {
-			List<String> roles = new ArrayList<>();
-			roles.add("Contributor");
-			contributors.add(new ModContributorImpl(contributor.getName(), roles));
+			addRoleToContributor(contributorRoles, contributor.getName(), "Contributor");
 		}
+
+		List<ModContributor> contributors = new ArrayList<>();
+
+		for (Map.Entry<String, List<String>> entry : contributorRoles.entrySet()) {
+			contributors.add(new ModContributorImpl(entry.getKey(), entry.getValue()));
+		}
+
 		return Collections.unmodifiableList(contributors);
 	}
 


### PR DESCRIPTION
Fix edge case when a Fabric mod has the same name in both the `authors` and `contributors` list producing two separate mod contributors during translation instead of a single one with two roles.

I'm not sure if there is actually any mods with this sort of duplicate metadata out there in the wild but I ran into it when testing something earlier and figured it'd be good to fix it anyway for correctness sake.