### PR TITLE
Allowed the GameProvider to provide the namespace

### DIFF
--- a/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/MinecraftGameProvider.java
+++ b/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/MinecraftGameProvider.java
@@ -50,6 +50,7 @@ import org.quiltmc.loader.impl.game.minecraft.patch.BrandingPatch;
 import org.quiltmc.loader.impl.game.minecraft.patch.EntrypointPatch;
 import org.quiltmc.loader.impl.game.minecraft.patch.TinyFDPatch;
 import org.quiltmc.loader.impl.launch.common.QuiltLauncher;
+import org.quiltmc.loader.impl.launch.common.QuiltLauncherBase;
 import org.quiltmc.loader.impl.metadata.qmj.V1ModMetadataBuilder;
 import org.quiltmc.loader.impl.util.Arguments;
 import org.quiltmc.loader.impl.util.ExceptionUtil;
@@ -187,6 +188,11 @@ public class MinecraftGameProvider implements GameProvider {
 	@Override
 	public boolean isObfuscated() {
 		return true; // generally yes...
+	}
+
+	@Override
+	public String getNamespace() {
+		return QuiltLauncherBase.getLauncher().isDevelopment() ? "named" : "intermediary";
 	}
 
 	@Override
@@ -431,7 +437,7 @@ public class MinecraftGameProvider implements GameProvider {
 
 		setupLogHandler(launcher, true);
 
-		transformer.locateEntrypoints(launcher, gameJars);
+		transformer.locateEntrypoints(launcher, getNamespace(), gameJars);
 	}
 
 	private void setupLogHandler(QuiltLauncher launcher, boolean useTargetCl) {

--- a/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/patch/BrandingPatch.java
+++ b/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/patch/BrandingPatch.java
@@ -30,7 +30,7 @@ import java.util.ListIterator;
 
 public final class BrandingPatch extends GamePatch {
 	@Override
-	public void process(QuiltLauncher launcher, GamePatchContext context) {
+	public void process(QuiltLauncher launcher, String namespace, GamePatchContext context) {
 		for (String brandClassName : new String[] {
 				"net.minecraft.client.ClientBrandRetriever",
 				"net.minecraft.server.MinecraftServer"

--- a/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/patch/EntrypointPatch.java
+++ b/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/patch/EntrypointPatch.java
@@ -75,7 +75,7 @@ public class EntrypointPatch extends GamePatch {
 	}
 
 	@Override
-	public void process(QuiltLauncher launcher, GamePatchContext context) {
+	public void process(QuiltLauncher launcher, String namespace, GamePatchContext context) {
 		EnvType type = launcher.getEnvironmentType();
 		String entrypoint = launcher.getEntrypoint();
 		Version gameVersion = getGameVersion();

--- a/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/patch/TinyFDPatch.java
+++ b/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/patch/TinyFDPatch.java
@@ -51,8 +51,15 @@ public final class TinyFDPatch extends GamePatch {
 			return;
 		}
 
+		String className = MORE_OPTIONS_DIALOG_CLASS_NAME;
 
-		final ClassNode classNode = context.getClassNode(MORE_OPTIONS_DIALOG_CLASS_NAME);
+		// Only remap the classname when needed to prevent loading the mappings when not required in prod.
+		if (!launcher.getMappingConfiguration().getTargetNamespace().equals("intermediary")
+				&& QuiltLoader.getMappingResolver().getNamespaces().contains("intermediary")) {
+			className = QuiltLoader.getMappingResolver().mapClassName("intermediary", MORE_OPTIONS_DIALOG_CLASS_NAME);
+		}
+
+		final ClassNode classNode = context.getClassNode(className);
 
 		if (classNode == null) {
 			// Class is not present in this version, nothing to do.

--- a/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/patch/TinyFDPatch.java
+++ b/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/patch/TinyFDPatch.java
@@ -45,21 +45,14 @@ public final class TinyFDPatch extends GamePatch {
 	private static final String DIALOG_TITLE = "Select settings file (.json)";
 
 	@Override
-	public void process(QuiltLauncher launcher, GamePatchContext context) {
+	public void process(QuiltLauncher launcher, String namespace, GamePatchContext context) {
 		if (launcher.getEnvironmentType() != EnvType.CLIENT) {
 			// Fix should only be applied to clients.
 			return;
 		}
 
-		String className = MORE_OPTIONS_DIALOG_CLASS_NAME;
 
-		// Only remap the classname when needed to prevent loading the mappings when not required in prod.
-		if (!launcher.getMappingConfiguration().getTargetNamespace().equals("intermediary")
-				&& QuiltLoader.getMappingResolver().getNamespaces().contains("intermediary")) {
-			className = QuiltLoader.getMappingResolver().mapClassName("intermediary", MORE_OPTIONS_DIALOG_CLASS_NAME);
-		}
-
-		final ClassNode classNode = context.getClassNode(className);
+		final ClassNode classNode = context.getClassNode(MORE_OPTIONS_DIALOG_CLASS_NAME);
 
 		if (classNode == null) {
 			// Class is not present in this version, nothing to do.

--- a/src/main/java/org/quiltmc/loader/impl/entrypoint/GamePatch.java
+++ b/src/main/java/org/quiltmc/loader/impl/entrypoint/GamePatch.java
@@ -128,12 +128,20 @@ public abstract class GamePatch {
 		return ((access & 0x0F) == (Opcodes.ACC_PUBLIC | 0 /* non-static */));
 	}
 
-	public void process(QuiltLauncher launcher, Function<String, ClassReader> classSource, Consumer<ClassNode> classEmitter) {
+	public void process(QuiltLauncher launcher, String namespace, Function<String, ClassReader> classSource, Consumer<ClassNode> classEmitter) {
 		throw new AbstractMethodError(getClass() + " must override one of the 'process' methods!");
 	}
+	@Deprecated
+	public void process(QuiltLauncher launcher, Function<String, ClassReader> classSource, Consumer<ClassNode> classEmitter) {
+		process(launcher, "intermediary", classSource, classEmitter);
+	}
 
+	public void process(QuiltLauncher launcher, String namespace, GamePatchContext context) {
+		process(launcher, namespace, context::getClassSourceReader, context::addPatchedClass);
+	}
+	@Deprecated
 	public void process(QuiltLauncher launcher, GamePatchContext context) {
-		process(launcher, context::getClassSourceReader, context::addPatchedClass);
+		process(launcher, "intermediary", context);
 	}
 }
 

--- a/src/main/java/org/quiltmc/loader/impl/entrypoint/GamePatch.java
+++ b/src/main/java/org/quiltmc/loader/impl/entrypoint/GamePatch.java
@@ -133,14 +133,14 @@ public abstract class GamePatch {
 		throw new AbstractMethodError(getClass() + " must override one of the 'process' methods!");
 	}
 	public void process(QuiltLauncher launcher, Function<String, ClassReader> classSource, Consumer<ClassNode> classEmitter) {
-		process(launcher, QuiltLoaderImpl.INSTANCE.tryGetGameProvider().getNamespace(), classSource, classEmitter);
+		process(launcher, launcher.getTargetNamespace(), classSource, classEmitter);
 	}
 
 	public void process(QuiltLauncher launcher, String namespace, GamePatchContext context) {
 		process(launcher, namespace, context::getClassSourceReader, context::addPatchedClass);
 	}
 	public void process(QuiltLauncher launcher, GamePatchContext context) {
-		process(launcher, QuiltLoaderImpl.INSTANCE.tryGetGameProvider().getNamespace(), context);
+		process(launcher, launcher.getTargetNamespace(), context);
 	}
 }
 

--- a/src/main/java/org/quiltmc/loader/impl/entrypoint/GamePatch.java
+++ b/src/main/java/org/quiltmc/loader/impl/entrypoint/GamePatch.java
@@ -18,6 +18,7 @@
 package org.quiltmc.loader.impl.entrypoint;
 
 import org.objectweb.asm.ClassReader;
+import org.quiltmc.loader.impl.QuiltLoaderImpl;
 import org.quiltmc.loader.impl.launch.common.QuiltLauncher;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
@@ -131,17 +132,15 @@ public abstract class GamePatch {
 	public void process(QuiltLauncher launcher, String namespace, Function<String, ClassReader> classSource, Consumer<ClassNode> classEmitter) {
 		throw new AbstractMethodError(getClass() + " must override one of the 'process' methods!");
 	}
-	@Deprecated
 	public void process(QuiltLauncher launcher, Function<String, ClassReader> classSource, Consumer<ClassNode> classEmitter) {
-		process(launcher, "intermediary", classSource, classEmitter);
+		process(launcher, QuiltLoaderImpl.INSTANCE.tryGetGameProvider().getNamespace(), classSource, classEmitter);
 	}
 
 	public void process(QuiltLauncher launcher, String namespace, GamePatchContext context) {
 		process(launcher, namespace, context::getClassSourceReader, context::addPatchedClass);
 	}
-	@Deprecated
 	public void process(QuiltLauncher launcher, GamePatchContext context) {
-		process(launcher, "intermediary", context);
+		process(launcher, QuiltLoaderImpl.INSTANCE.tryGetGameProvider().getNamespace(), context);
 	}
 }
 

--- a/src/main/java/org/quiltmc/loader/impl/entrypoint/GameTransformer.java
+++ b/src/main/java/org/quiltmc/loader/impl/entrypoint/GameTransformer.java
@@ -66,6 +66,9 @@ public class GameTransformer {
 		patchedClasses.put(key, writer.toByteArray());
 	}
 
+	public void locateEntrypoints(QuiltLauncher launcher, List<Path> gameJars) {
+		this.locateEntrypoints(launcher, null, gameJars);
+	}
 	public void locateEntrypoints(QuiltLauncher launcher, String namespace, List<Path> gameJars) {
 		if (entrypointsLocated) {
 			return;
@@ -129,7 +132,10 @@ public class GameTransformer {
 			};
 
 			for (GamePatch patch : patches) {
-				patch.process(launcher, namespace, context);
+				if (namespace == null)
+					patch.process(launcher, context);
+				else
+					patch.process(launcher, namespace, context);
 			}
 
 			for (ClassNode node : addedClassNodes.values()) {

--- a/src/main/java/org/quiltmc/loader/impl/entrypoint/GameTransformer.java
+++ b/src/main/java/org/quiltmc/loader/impl/entrypoint/GameTransformer.java
@@ -66,7 +66,7 @@ public class GameTransformer {
 		patchedClasses.put(key, writer.toByteArray());
 	}
 
-	public void locateEntrypoints(QuiltLauncher launcher, List<Path> gameJars) {
+	public void locateEntrypoints(QuiltLauncher launcher, String namespace, List<Path> gameJars) {
 		if (entrypointsLocated) {
 			return;
 		}
@@ -129,7 +129,7 @@ public class GameTransformer {
 			};
 
 			for (GamePatch patch : patches) {
-				patch.process(launcher, context);
+				patch.process(launcher, namespace, context);
 			}
 
 			for (ClassNode node : addedClassNodes.values()) {

--- a/src/main/java/org/quiltmc/loader/impl/game/GameProvider.java
+++ b/src/main/java/org/quiltmc/loader/impl/game/GameProvider.java
@@ -44,6 +44,9 @@ public interface GameProvider {
 	String getEntrypoint();
 	Path getLaunchDirectory();
 	boolean isObfuscated();
+	default String getNamespace() {
+		return isObfuscated()? "intermediary": "named";
+	};
 	boolean requiresUrlClassLoader();
 
 	boolean isEnabled();

--- a/src/main/java/org/quiltmc/loader/impl/launch/common/MappingConfiguration.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/common/MappingConfiguration.java
@@ -79,8 +79,6 @@ public final class MappingConfiguration {
 		return mappings;
 	}
 
-	@Deprecated
-	/** Use {@link GameProvider#getNamespace()} instead */
 	public String getTargetNamespace() {
 		return QuiltLoaderImpl.INSTANCE.tryGetGameProvider().getNamespace();
 	}

--- a/src/main/java/org/quiltmc/loader/impl/launch/common/MappingConfiguration.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/common/MappingConfiguration.java
@@ -31,6 +31,8 @@ import java.util.zip.ZipError;
 import net.fabricmc.mapping.tree.TinyMappingFactory;
 import net.fabricmc.mapping.tree.TinyTree;
 
+import org.quiltmc.loader.impl.QuiltLoaderImpl;
+import org.quiltmc.loader.impl.game.GameProvider;
 import org.quiltmc.loader.impl.util.ManifestUtil;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
@@ -77,8 +79,10 @@ public final class MappingConfiguration {
 		return mappings;
 	}
 
+	@Deprecated
+	/** Use {@link GameProvider#getNamespace()} instead */
 	public String getTargetNamespace() {
-		return QuiltLauncherBase.getLauncher().isDevelopment() ? "named" : "intermediary";
+		return QuiltLoaderImpl.INSTANCE.tryGetGameProvider().getNamespace();
 	}
 
 	public boolean requiresPackageAccessHack() {

--- a/src/main/java/org/quiltmc/loader/impl/launch/common/MappingConfiguration.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/common/MappingConfiguration.java
@@ -80,7 +80,12 @@ public final class MappingConfiguration {
 	}
 
 	public String getTargetNamespace() {
-		return QuiltLoaderImpl.INSTANCE.tryGetGameProvider().getNamespace();
+		GameProvider gameProvider = QuiltLoaderImpl.INSTANCE.tryGetGameProvider();
+		if (gameProvider != null)
+			return gameProvider.getNamespace();
+		// else
+		// If the game provider doesn't exist yet, use the development flag to set the namespace
+		return QuiltLauncherBase.getLauncher().isDevelopment() ? "named" : "intermediary";
 	}
 
 	public boolean requiresPackageAccessHack() {


### PR DESCRIPTION
This PR adds a new optional function to the GameProvider called `getNamespace` to allow it to provide the namespace of the current session (which should be either be "named" or "intermediary").\
It also exposes the namespace to the GamePatch allowing it to be passed as an argument to it.

~~This PR also removes [these lines in TinyFDPatch](https://github.com/QuiltMC/quilt-loader/blob/5e36a6f0d615bf3d07261ed94c26850d6910280e/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/patch/TinyFDPatch.java#L57) as (to the best of my knowledge), it will always return false (`launcher.getMappingConfiguration().getTargetNamespace()` and `QuiltLoader.getMappingResolver().getNamespaces()` are always the same), unless something went wrong (where the namespace is called something other than "named" or "intermediary").~~
Reverted this change as it will be needed for the planned `hashed` mappings/namespace (https://github.com/QuiltMC/quilt-loader/pull/428#discussion_r1590394769)