### PR TITLE
Fix knot class loading allowlist not working

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/launch/knot/KnotClassDelegate.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/knot/KnotClassDelegate.java
@@ -244,11 +244,19 @@ class KnotClassDelegate {
 			}
 		}
 
-		if (!allowedPrefixes.isEmpty()) {
+		if (!allowedPrefixes.isEmpty() && url != null) {
+			String fileName = LoaderUtil.getClassFileName(name);
+			URL codeSource = null;
+
+			try {
+				codeSource = UrlUtil.getSource(fileName, url);
+			} catch (UrlConversionException e) {
+				Log.warn(LogCategory.GENERAL, "Failed to get the code source URL for " + url);
+			}
+
 			String[] prefixes;
 
-			if (url != null
-					&& (prefixes = allowedPrefixes.get(url.toString())) != null) {
+			if (codeSource != null && (prefixes = allowedPrefixes.get(codeSource.toString())) != null) {
 				assert prefixes.length > 0;
 				boolean found = false;
 
@@ -260,7 +268,7 @@ class KnotClassDelegate {
 				}
 
 				if (!found) {
-					throw new ClassNotFoundException("class "+name+" is currently restricted from being loaded");
+					throw new ClassNotFoundException("class " + name + " is currently restricted from being loaded");
 				}
 			}
 		}
@@ -349,7 +357,6 @@ class KnotClassDelegate {
 		}
 		return c;
 	}
-
 
 	private boolean shouldRerouteToParent(String name) {
 		return name.startsWith("org.slf4j.") || name.startsWith("org.apache.logging.log4j.");

--- a/src/main/java/org/quiltmc/loader/impl/util/UrlUtil.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/UrlUtil.java
@@ -77,7 +77,7 @@ public final class UrlUtil {
 	}
 
 	public static URL asUrl(Path path) throws MalformedURLException {
-		return path.toUri().toURL();
+		return LoaderUtil.normalizePath(path).toUri().toURL();
 	}
 
 	public static Path getCodeSource(URL url, String localPath) throws UrlConversionException {


### PR DESCRIPTION
Resolves #251.

The method of looking up which prefixes were (dis)allowed was flawed as it always looked up using the entire path to a class file (including the part in the jar), whereas the allowlist only maps from the path to the jar to allowed prefixes in the jar.

I've also changed `UrlUtil.asUrl` to normalize the path as otherwise it produces URLs with a full stop at the current working directory, which caused issues with looking up the prefixes as well. See an equivalent example:
```diff
- Path.of("./src/hello.txt").toUri().toURL();
- $1 ==> file:/C:/Users/lilly/projects/quilt-loader/./src/hello.txt
+ Path.of("./src/hello.txt").toAbsolutePath().normalize().toUri().toURL();
+ $2 ==> file:/C:/Users/lilly/projects/quilt-loader/src/hello.txt
```
