### PR TITLE
add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report Quilt Standard Libs issues here
+    url: https://github.com/QuiltMC/quilt-standard-libraries/issues/new/choose
+    about: Instead of Reporting QSL issues in the Quilt Loader issue tracker, do so in the QSL issue tracker.
+
+  - name: Join the Discord for support.
+    url: https://discord.quiltmc.org
+    about: Discuss the Quilt Loader on our Discord server.

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -1,0 +1,38 @@
+name: Crash Report
+description: Create a crash report to receive support for a breaking issue.
+labels: [support, crash]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking your time to report this crash! If you need real-time help, join us on [Discord](https://discord.quiltmc.org).
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the crash
+      description: "Describe the crash as clearly as possible. The more detail you provide means the sooner you can get back to your game! This includes: steps to reproduce or situation right before the crash, recent changes you made to your mods list, or any additional context that could be helpful."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Which environment crashed?
+      options:
+        - Client
+        - Server
+        - Both
+    validations:
+      required: true
+
+  - type: input
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        If applicable (crash, error output in console), please provide your crash report or latest.log
+        To upload logs, use [MCLogs](https://mclo.gs/) to upload your crashlog or latest.log. If you are unsure of how to obtain a crash report, read [here](https://minecraft.wiki/w/Tutorials/Obtaining_a_crash_report).
+        Crash reports without a crashlog or a latest.log file will be marked as invalid. Crashes are hard to fix without the crashlogs or latest.log file(s).
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/loader_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/loader_bug_report.yml
@@ -18,7 +18,7 @@ body:
   - type: textarea
     id: where-in-loader
     attributes:
-      label: How did QSL break?
+      label: How did Quilt Loader break?
       description: "What parts of Quilt Loader were in the stack trace? Is it possible to provide a GitHub link to the section of Quilt Loader that is broken?"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/loader_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/loader_bug_report.yml
@@ -1,0 +1,43 @@
+name: Quilt Loader-specific Bug Report
+description: Create a bug report to help us fix issues with the Quilt Loader.
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking your time to report this bug! If you need real-time help, join us on [Discord](https://discord.quiltmc.org).
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: "Describe the bug as clearly as possible. The more detail you provide means the sooner the bug can be fixed! This includes: steps to reproduce or situation you encountered the bug in, recent changes you made to your mods list, or any additional context that could be helpful."
+    validations:
+      required: true
+
+  - type: textarea
+    id: where-in-loader
+    attributes:
+      label: How did QSL break?
+      description: "What parts of Quilt Loader were in the stack trace? Is it possible to provide a GitHub link to the section of Quilt Loader that is broken?"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Which environment did you encounter this bug in?
+      options:
+        - Client
+        - Server
+        - Both
+    validations:
+      required: true
+
+  - type: input
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        If applicable, please provide your crash report or latest.log
+        To upload logs, use [MCLogs](https://mclo.gs/) to upload your latest.log. If you are unsure of how to obtain a log, read [here](https://minecraft.wiki/w/Tutorials/Obtaining_a_crash_report).


### PR DESCRIPTION
the crash report and bug report templates were ported from https://github.com/QuiltMC/quilt-standard-libraries/pull/380 with some edits to fit the loader repo