### PR TITLE
Optimize boot times by not copying to JAR when unnecessary

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -485,7 +485,7 @@ public final class QuiltLoaderImpl {
 				// Versions before 1.17.1 don't work very well if they aren't at the root of their zip file
 				return true;
 			}
-			if (modIds.contains("fabric-resource-loader-v0")) {
+			if (modIds.contains("fabric-resource-loader-v0") && !modIds.contains("quilted_fabric_resource_loader_v0")) {
 				if (Version.of("1.19.3").compareTo(mod.version()) > 0) {
 					// Fabric API turns minecraft into a resource pack to load from instead of using the classpath,
 					// so it also doesn't work very well

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -486,9 +486,11 @@ public final class QuiltLoaderImpl {
 				return true;
 			}
 			if (modIds.contains("fabric-resource-loader-v0")) {
-				// Fabric API turns minecraft into a resource pack to load from instead of using the classpath,
-				// so it also doesn't work very well
-				return true;
+				if (Version.of("1.19.3").compareTo(mod.version()) > 0) {
+					// Fabric API turns minecraft into a resource pack to load from instead of using the classpath,
+					// so it also doesn't work very well
+					return true;
+				}
 			}
 			if (modIds.contains("polymer")) {
 				if (Version.of("1.19.3").compareTo(mod.version()) >= 0) {


### PR DESCRIPTION
Once upon a time, a commit happened where in order to fix shenanigans, a deal with the devil was done: if you had Fabric Resource Loader API v0 installed, no matter if you had the Quilted variant, you were going to suffer long load times. This was a terrible deal! But every deal has a fix..

This PR optimizes up to ten seconds (or more! I haven't measured properly) of load times by simply not copying the jar unnecessarily every time the game starts, making dev envs snappier and player happier (I am happier lmfao)

This has been tested on Minecraft 1.21.1, 1.20.1, 1.19.4, 1.19.3, 1.19.2 and 1.18.2 in order to determine the bounds as well as whenever QFAPI was a sure way of fixing the crash