### PR TITLE
Add a reflective name fixer, used for various calls in Class and MethodHandles.Lookup

### DIFF
--- a/minecraft/minecraft-test/src/main/java/net/fabricmc/minecraft/test/FabricEntrypointTest.java
+++ b/minecraft/minecraft-test/src/main/java/net/fabricmc/minecraft/test/FabricEntrypointTest.java
@@ -1,10 +1,98 @@
 package net.fabricmc.minecraft.test;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import org.jetbrains.annotations.Nullable;
+import org.quiltmc.loader.api.MappingResolver;
+import org.quiltmc.loader.api.QuiltLoader;
+import org.quiltmc.loader.impl.launch.common.QuiltLauncherBase;
+
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.mappingio.tree.MappingTreeView;
+import net.fabricmc.mappingio.tree.MappingTreeView.MethodMappingView;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.item.CompassItem;
+import net.minecraft.item.DyeItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.world.World;
 
 public class FabricEntrypointTest implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		System.out.println("testmod initialized!");
+
+		System.out.println("Testing ReflectiveFixer");
+		try {
+			String clnom = ServerPlayerEntity.class.getName() + "$2"; // An anonymous inner class
+			Class<?> cls = Class.forName(clnom, true, FabricEntrypointTest.class.getClassLoader());
+			MappingResolver mappings = QuiltLoader.getMappingResolver();
+			MappingTreeView mappingsView = QuiltLauncherBase.getLauncher().getMappingConfiguration().getMappings();
+			String currentNamespace = mappings.getCurrentRuntimeNamespace();
+
+			for (String namespace : mappings.getNamespaces()) {
+				String name = mappings.unmapClassName(namespace, cls.getName());
+				System.out.println(
+					"[" + (currentNamespace.equals(namespace) ? "x" : " ") + "] " + namespace + " = " + name
+				);
+			}
+
+			System.out.println(cls.getName());
+			System.out.println(Arrays.toString(cls.getInterfaces()));
+			System.out.println(cls.getDeclaredField("field_29183"));
+			System.out.println(cls.getField("field_29183"));
+			MethodHandle getter = MethodHandles.privateLookupIn(cls, MethodHandles.lookup()).findGetter(
+				cls, "field_29183", ServerPlayerEntity.class
+			);
+			int h = 0;
+			for (int i = 0; i < 100_000; i++) {
+				MethodHandle handle = MethodHandles.privateLookupIn(cls, MethodHandles.lookup()).findGetter(
+					cls, "field_29183", ServerPlayerEntity.class
+				);
+				h = h + 1 * handle.hashCode();
+			}
+			System.out.println(h);
+			System.out.println("Obtained getter " + getter + " as " + getter.type().toMethodDescriptorString());
+
+			// inventoryTick (ItemStack stack, World world, Entity entity, int slot, boolean selected)V
+			MethodType type = MethodType.methodType(void.class, ItemStack.class, World.class, Entity.class, int.class, boolean.class);
+			String intermediaryName = null;
+			for (Method m : Item.class.getDeclaredMethods()) {
+				if (m.getReturnType() != type.returnType() || !Arrays.equals(type.parameterArray(), m.getParameterTypes())) {
+					continue;
+				}
+				System.out.println(m.getName());
+				// Should we publish this as API?
+				int i = mappingsView.getNamespaceId("named");
+				MethodMappingView method = mappingsView.getMethod(Item.class.getName().replace('.', '/'), "inventoryTick", type.descriptorString(), i);
+				if (method != null) {
+					System.out.println(method.getName("official"));
+					System.out.println(intermediaryName = method.getName("intermediary"));
+					System.out.println(method.getName("named"));
+					break;
+				}
+			}
+			System.out.println("Method Name = " + intermediaryName);
+			System.out.println("Method (Virtual) = " + MethodHandles.lookup().findVirtual(CompassItem.class, intermediaryName, type));
+			Lookup privateInItem = MethodHandles.privateLookupIn(Item.class, MethodHandles.lookup());
+			System.out.println("Method (Special) = " + privateInItem.findSpecial(Item.class, intermediaryName, type, Item.class));
+
+			System.out.println("Method (Declared) = " + Item.class.getDeclaredMethod(intermediaryName, type.parameterArray()));
+			System.out.println("Method (Any) = " + CompassItem.class.getMethod(intermediaryName, type.parameterArray()));
+
+			int namespace = mappingsView.getNamespaceId("named");
+			MethodMappingView method = mappingsView.getMethod(CompassItem.class.getName().replace('.', '/'), "getSpawnPosition", null, namespace);
+			System.out.println("getSpawnPosition = " + method);
+
+		} catch (ReflectiveOperationException e) {
+			throw new Error(e);
+		}
 	}
 }

--- a/src/main/java/org/quiltmc/loader/api/MappingResolver.java
+++ b/src/main/java/org/quiltmc/loader/api/MappingResolver.java
@@ -20,7 +20,7 @@ package org.quiltmc.loader.api;
 import java.util.Collection;
 
 /**
- * Helper class for performing mapping resolution.
+ * Helper class for performing mapping resolution. This can be obtained through {@link QuiltLoader#getMappingResolver()}.
  *
  * <p><strong>Note</strong>: The target namespace (the one being mapped to) for mapping (or the
  * source one for unmapping) is always implied to be the one Loader is

--- a/src/main/java/org/quiltmc/loader/impl/game/MappingConfigurationImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/game/MappingConfigurationImpl.java
@@ -65,7 +65,7 @@ public class MappingConfigurationImpl implements MappingConfiguration {
 	private String gameId;
 	private String gameVersion;
 	private String mappingsSource;
-	private VisitableMappingTree mappings = new MemoryMappingTree();
+	private VisitableMappingTree mappings = new MemoryMappingTree(true);
 	private List<String> namespaces;
 	private String targetNamespace;
 

--- a/src/main/java/org/quiltmc/loader/impl/transformer/InternalsHiderTransform.java
+++ b/src/main/java/org/quiltmc/loader/impl/transformer/InternalsHiderTransform.java
@@ -172,18 +172,14 @@ public class InternalsHiderTransform {
 
 				return new MethodVisitor(api, sup) {
 
+					boolean hasIllegal = false;
+
 					@Override
 					public void visitCode() {
 						super.visitCode();
 						if (isClassInit && !illegalSupers.isEmpty()) {
 							prefixClassInitErrors(sup);
 						}
-					}
-
-					@Override
-					public void visitMaxs(int maxStack, int maxLocals) {
-						// Sadly nothing we can do about this, since errors might occur anywhere :/
-						super.visitMaxs(maxStack + 1, maxLocals);
 					}
 
 					@Override
@@ -201,6 +197,7 @@ public class InternalsHiderTransform {
 						}
 
 						if (set != null && !set.isPermitted(mod)) {
+							hasIllegal = true;
 							super.visitLdcInsn(set.generateError(mod, "the field " + owner + "." + name, className + "." + mthName + mthDescriptor));
 							super.visitMethodInsn(
 								Opcodes.INVOKESTATIC, METHOD_OWNER, set.getInvokeMethodName(), "(Ljava/lang/String;)V",
@@ -228,6 +225,7 @@ public class InternalsHiderTransform {
 						}
 
 						if (set != null && !set.isPermitted(mod)) {
+							hasIllegal = true;
 							super.visitLdcInsn(
 								set.generateError(mod, "the method " + owner + "." + name + descriptor, className + "." + mthName + mthDescriptor)
 							);
@@ -238,6 +236,13 @@ public class InternalsHiderTransform {
 						}
 
 						super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+					}
+
+					@Override
+					public void visitMaxs(int maxStack, int maxLocals) {
+						// Ideally we'd track the actual stack value to figure out if we truly need to increase it
+						// But this is *much* easier
+						super.visitMaxs(maxStack + (hasIllegal ? 1 : 0), maxLocals);
 					}
 				};
 			}

--- a/src/main/java/org/quiltmc/loader/impl/transformer/QuiltReflectiveFixUtil.java
+++ b/src/main/java/org/quiltmc/loader/impl/transformer/QuiltReflectiveFixUtil.java
@@ -1,0 +1,570 @@
+/*
+ * Copyright 2024 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.loader.impl.transformer;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.quiltmc.loader.api.MappingResolver;
+import org.quiltmc.loader.api.QuiltLoader;
+import org.quiltmc.loader.impl.launch.common.QuiltLauncherBase;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
+
+import net.fabricmc.mappingio.tree.MappingTreeView;
+import net.fabricmc.mappingio.tree.MappingTreeView.ClassMappingView;
+import net.fabricmc.mappingio.tree.MappingTreeView.FieldMappingView;
+import net.fabricmc.mappingio.tree.MappingTreeView.MethodMappingView;
+
+/** Internal class. For technical reasons this class cannot be fully private, but it's usage is not recommended.
+ * <p>
+ * Specifically the methods in this class are added before calls to java reflection methods to fix issues with
+ * mappings. */
+@QuiltLoaderInternal(QuiltLoaderInternalType.LEGACY_NO_WARN)
+// The ReflectiveFixer is applied before the InternalsHider
+// which means we don't know if a mod uses this directly, or if it's been added by ReflectiveFixer
+// So we must make this LEGACY_NO_WARN to prevent unavoidable warnings or errors.
+public class QuiltReflectiveFixUtil {
+
+	private static Map<String, Set<String>> namedOuterToInnerClassCache;
+
+	/** Fixes a class name that is about to be passed to {@link Class#forName(String)} to ensure it's correctly
+	 * mapped. */
+	public static String fixClassName(String name) {
+
+		// Handle improperly named inner classes
+		// This mostly occurs when the class is anonymous (and so has a "$1" name in intermediary)
+		// but has a full name in hashed "$C_abcdef"
+
+		// Then if a mod does something like MinecraftType.class.getName() + "$1"
+		// and we're currently running in hashed (or other mapped that's based on hashed)
+		// then it won't find the real class name (since it will be "MinecraftType$C_abcdef")
+
+		// The way we deal with this is by finding all of the inner-classes of the outermost type,
+		// then mapping every inner-class step with different mappings until we unmap to the current namespace.
+
+		int dollarIndex = name.indexOf('$');
+
+		if (dollarIndex < 0) {
+			// Not an inner class, not something we deal with here
+			return name;
+		}
+
+		if (namedOuterToInnerClassCache == null) {
+			Map<String, Set<String>> map = new HashMap<>();
+
+			MappingResolver mappings = QuiltLoader.getMappingResolver();
+			MappingTreeView tree = QuiltLauncherBase.getLauncher().getMappingConfiguration().getMappings();
+			int namespace = tree.getNamespaceId(mappings.getCurrentRuntimeNamespace());
+
+			for (ClassMappingView cls : tree.getClasses()) {
+				String className = cls.getName(namespace);
+				if (className == null) {
+					continue;
+				}
+
+				boolean replaced = false;
+				while (true) {
+					int idx = className.lastIndexOf('$');
+					if (idx < 0) {
+						break;
+					}
+
+					if (!replaced) {
+						// Slight optimisation: only replace class names
+						// if we actually need to process them
+						className = className.replace('/', '.');
+						replaced = true;
+					}
+
+					String outer = className.substring(0, idx);
+					map.computeIfAbsent(outer, o -> new HashSet<>()).add(className);
+					className = outer;
+				}
+			}
+
+			namedOuterToInnerClassCache = map;
+		}
+
+		// Now we have:
+		// name = "net.OuterClass$InnerClass"
+		// but "net.OuterClass" and "$InnerClass" will be using different namespaces
+		// (Specifically "net.OuterClass" will be in the correct namespace)
+
+		String correctName = name.substring(0, dollarIndex);
+		MappingResolver mappings = QuiltLoader.getMappingResolver();
+
+		subNameLoop: while (dollarIndex > 0) {
+
+			Set<String> innerClasses = namedOuterToInnerClassCache.get(correctName);
+
+			if (innerClasses == null) {
+				// Not a mapped class
+				return name;
+			}
+
+			int nextDollarIndex = name.indexOf("$", dollarIndex + 1);
+
+			String incorrectSubName;
+			if (nextDollarIndex < 0) {
+				incorrectSubName = name.substring(dollarIndex + 1, name.length());
+			} else {
+				incorrectSubName = name.substring(dollarIndex + 1, nextDollarIndex);
+			}
+
+			for (String namespace : mappings.getNamespaces()) {
+				String testNamePrefix = mappings.unmapClassName(namespace, correctName);
+				String testName = testNamePrefix + "$" + incorrectSubName;
+				String correctTestName = mappings.mapClassName(namespace, testName);
+
+				if (innerClasses.contains(correctTestName)) {
+					correctName = correctTestName;
+					dollarIndex = nextDollarIndex;
+					continue subNameLoop;
+				}
+			}
+
+			// We didn't find a correct mapping
+			return name;
+		}
+
+		return correctName;
+	}
+
+	public static String fixDeclaredFieldName(String fieldName, Class<?> classIn) {
+		try {
+			classIn.getDeclaredField(fieldName);
+			// No need to fix it if it already exists
+			return fieldName;
+		} catch (NoSuchFieldException e) {
+			// Ignored - this just means we should
+		}
+
+		MappingResolver resolver = QuiltLoader.getMappingResolver();
+		String runtimeNamespace = resolver.getCurrentRuntimeNamespace();
+
+		MappingTreeView mappings = QuiltLauncherBase.getLauncher().getMappingConfiguration().getMappings();
+		String name = getMappingsName(classIn);
+		ClassMappingView classMappings = mappings.getClass(name, mappings.getNamespaceId(runtimeNamespace));
+
+		if (classMappings == null) {
+			return fieldName;
+		}
+
+		Collection<String> namespaces = resolver.getNamespaces();
+
+		for (FieldMappingView f : classMappings.getFields()) {
+			for (String namespace : namespaces) {
+				if (f.getName(namespace).equals(fieldName)) {
+					return f.getName(runtimeNamespace);
+				}
+			}
+		}
+
+		return fieldName;
+	}
+
+	private static String getMappingsName(Class<?> classIn) {
+		return classIn.getName().replace('.', '/');
+	}
+
+	public static String fixFieldName(String fieldName, Class<?> classIn) {
+		try {
+			classIn.getField(fieldName);
+			// No need to fix it if it already exists
+			return fieldName;
+		} catch (NoSuchFieldException e) {
+			// Ignored - this just means we should
+		}
+
+		MappingTreeView mappings = QuiltLauncherBase.getLauncher().getMappingConfiguration().getMappings();
+		MappingResolver resolver = QuiltLoader.getMappingResolver();
+		String runtimeNamespace = resolver.getCurrentRuntimeNamespace();
+		int namespaceId = mappings.getNamespaceId(runtimeNamespace);
+
+		Set<Class<?>> testedClasses = new HashSet<>();
+
+		Map<String, List<Field>> possibleFields = new HashMap<>();
+		Field[] fieldArray = classIn.getFields();
+		for (Field field : fieldArray) {
+			possibleFields.computeIfAbsent(field.getName(), f -> new ArrayList<>()).add(field);
+		}
+
+		for (Field field : fieldArray) {
+			Class<?> owner = field.getDeclaringClass();
+			if (!testedClasses.add(owner)) {
+				continue;
+			}
+			ClassMappingView ownerMappings = mappings.getClass(getMappingsName(owner), namespaceId);
+			if (ownerMappings == null) {
+				continue;
+			}
+
+			for (FieldMappingView f : ownerMappings.getFields()) {
+				String currentName = f.getName(namespaceId);
+				for (Field possible : possibleFields.getOrDefault(currentName, Collections.emptyList())) {
+					if (possible.getDeclaringClass() != owner) {
+						continue;
+					}
+
+					for (String namespace : resolver.getNamespaces()) {
+						if (f.getName(namespace).equals(fieldName)) {
+							return currentName;
+						}
+					}
+				}
+			}
+		}
+
+		return fieldName;
+	}
+
+	public static MethodIntermediateArguments fixDeclaredMethodName(Class<?> classIn, String methodName, Class<?>[] args) {
+		try {
+			classIn.getDeclaredMethod(methodName, args);
+			// No need to fix it if it already exists
+			return new MethodIntermediateArguments(classIn, methodName, args);
+		} catch (NoSuchMethodException e) {
+			// Ignored - this just means we should
+		}
+
+		MappingResolver resolver = QuiltLoader.getMappingResolver();
+		String runtimeNamespace = resolver.getCurrentRuntimeNamespace();
+
+		MappingTreeView mappings = QuiltLauncherBase.getLauncher().getMappingConfiguration().getMappings();
+		String name = getMappingsName(classIn);
+		ClassMappingView classMappings = mappings.getClass(name, mappings.getNamespaceId(runtimeNamespace));
+
+		if (classMappings == null) {
+			return new MethodIntermediateArguments(classIn, methodName, args);
+		}
+
+		Collection<String> namespaces = resolver.getNamespaces();
+
+		String partialArgsDescriptor = MethodType.methodType(void.class, args).toMethodDescriptorString();
+		partialArgsDescriptor = partialArgsDescriptor.substring(1, partialArgsDescriptor.indexOf(')'));
+
+		for (MethodMappingView m : classMappings.getMethods()) {
+			String desc = m.getDesc(runtimeNamespace);
+			if (desc == null) {
+				// ?
+				continue;
+			}
+			// check descriptor equality, ignoring return type
+			desc = desc.substring(1, desc.indexOf(')'));
+
+			if (!desc.equals(partialArgsDescriptor)) {
+				continue;
+			}
+
+			for (String namespace : namespaces) {
+				if (m.getName(namespace).equals(methodName)) {
+					return new MethodIntermediateArguments(classIn, m.getName(runtimeNamespace), args);
+				}
+			}
+		}
+
+		return new MethodIntermediateArguments(classIn, methodName, args);
+	}
+
+	public static MethodIntermediateArguments fixMethodName(Class<?> classIn, String name, Class<?>[] args) {
+		try {
+			classIn.getMethod(name, args);
+			// No need to fix it if it already exists
+			return new MethodIntermediateArguments(classIn, name, args);
+		} catch (NoSuchMethodException e) {
+			// Ignored - this just means we should
+		}
+
+		MappingResolver resolver = QuiltLoader.getMappingResolver();
+
+		Collection<String> possibleNamespaces = new LinkedHashSet<>(resolver.getNamespaces());
+		possibleNamespaces.remove(resolver.getCurrentRuntimeNamespace());
+
+		for (Class<?> in : getMappableClassHierarchy(classIn)) {
+			for (Method m : in.getMethods()) {
+				if (!Arrays.equals(args, m.getParameterTypes())) {
+					// Skip expensive name checking
+					continue;
+				}
+
+				MethodType type = MethodType.methodType(m.getReturnType(), m.getParameterTypes());
+
+				for (String namespace : possibleNamespaces) {
+					String className = resolver.unmapClassName(namespace, in.getName());
+					String unMappedDesc = mapMethodTypeDescriptor(namespace, type);
+					String mappedName = resolver.mapMethodName(namespace, className, name, unMappedDesc);
+					if (m.getName().equals(mappedName)) {
+						return new MethodIntermediateArguments(classIn, mappedName, args);
+					}
+				}
+			}
+		}
+
+		return new MethodIntermediateArguments(classIn, name, args);
+	}
+
+	@QuiltLoaderInternal(QuiltLoaderInternalType.LEGACY_NO_WARN)
+	public static final class MethodIntermediateArguments {
+		private final Class<?> owner;
+		private final String methodName;
+		private final Class<?>[] args;
+
+		private MethodIntermediateArguments(Class<?> owner, String methodName, Class<?>[] args) {
+			this.owner = owner;
+			this.methodName = methodName;
+			this.args = args;
+		}
+
+		public Class<?> getOwner() {
+			return owner;
+		}
+
+		public String getMethodName() {
+			return methodName;
+		}
+
+		public Class<?>[] getArgs() {
+			return args;
+		}
+	}
+
+	/** Used to avoid needing to deal with local variables in {@link Lookup} redirects. */
+	@QuiltLoaderInternal(QuiltLoaderInternalType.LEGACY_NO_WARN)
+	public static final class LookupIntermediateArguments {
+		private final Lookup lookup;
+		private final Class<?> owner;
+		private final String name;
+		private final Class<?> fieldType;
+		private final MethodType methodType;
+		private Class<?> specialCaller;
+
+		private LookupIntermediateArguments(Lookup lookup, Class<?> owner, String name, Class<?> fieldType) {
+			this.lookup = lookup;
+			this.owner = owner;
+			this.name = name;
+			this.fieldType = fieldType;
+			this.methodType = null;
+		}
+
+		private LookupIntermediateArguments(Lookup lookup, Class<?> owner, String name, MethodType methodType) {
+			this.lookup = lookup;
+			this.owner = owner;
+			this.name = name;
+			this.fieldType = null;
+			this.methodType = methodType;
+		}
+
+		public Lookup getLookup() {
+			return lookup;
+		}
+
+		public Class<?> getOwner() {
+			return owner;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Class<?> getFieldType() {
+			return fieldType;
+		}
+
+		public MethodType getMethodType() {
+			return methodType;
+		}
+
+		public Class<?> getSpecialCaller() {
+			return specialCaller;
+		}
+	}
+
+	private static Set<Class<?>> getMappableClassHierarchy(Class<?> type) {
+		Set<Class<?>> set = new LinkedHashSet<>();
+		getMappableClassHierarchy(type, set);
+		return set;
+	}
+
+	private static void getMappableClassHierarchy(Class<?> type, Set<Class<?>> dst) {
+		String pkg = type.getPackage().getName();
+
+		if (pkg.startsWith("java.") || pkg.startsWith("org.quiltmc.loader.")) {
+			return;
+		}
+
+		// FIXME: Validate that we can just iterate through all classes!
+		// Like, what is the order for superinterfaces vs superclasses?
+
+		MappingResolver resolver = QuiltLoader.getMappingResolver();
+		MappingTreeView mappings = QuiltLauncherBase.getLauncher().getMappingConfiguration().getMappings();
+
+		int namespace = mappings.getNamespaceId(resolver.getCurrentRuntimeNamespace());
+		// Test if the given class is mappable
+		if (mappings.getClass(type.getName().replace('.', '/'), namespace) != null) {
+			if (!dst.add(type)) {
+				// Already visited
+				return;
+			}
+		}
+
+		Class<?> sup = type.getSuperclass();
+		if (sup != null) {
+			getMappableClassHierarchy(sup, dst);
+		}
+
+		for (Class<?> itf : type.getInterfaces()) {
+			getMappableClassHierarchy(itf, dst);
+		}
+	}
+
+	public static LookupIntermediateArguments fixLookupFindField(Lookup lookup, Class<?> owner, String name, Class<?> type) {
+
+		MappingResolver resolver = QuiltLoader.getMappingResolver();
+		String descriptor = Type.getDescriptor(type);
+
+		Collection<String> possibleNamespaces = new LinkedHashSet<>(resolver.getNamespaces());
+		possibleNamespaces.remove(resolver.getCurrentRuntimeNamespace());
+
+		for (Class<?> in : getMappableClassHierarchy(owner)) {
+			Lookup forTarget = lookup.in(in);
+			// Only return fields that the actual lookup is able to access
+			for (Field f : in.getDeclaredFields()) {
+				if (f.getType() != type) {
+					// Skip expensive name checking
+					continue;
+				}
+				// TODO: Handle modules
+				int mods = f.getModifiers() & (Opcodes.ACC_PUBLIC | Opcodes.ACC_PROTECTED | Opcodes.ACC_PRIVATE);
+				if (mods == 0) {
+					mods = MethodHandles.Lookup.PACKAGE;
+				}
+
+				if ((mods & forTarget.lookupModes()) != 0) {
+					// We can access the field
+
+					for (String namespace : possibleNamespaces) {
+						String className = resolver.unmapClassName(namespace, in.getName());
+						String unMappedDesc = descriptor;
+						int idxL = unMappedDesc.indexOf('L');
+						if (idxL >= 0) {
+							String mappedDescType = unMappedDesc.substring(idxL + 1, unMappedDesc.length() - 1);
+							unMappedDesc = unMappedDesc.substring(0, idxL + 1) //
+								+ resolver.unmapClassName(namespace, mappedDescType.replace('/', '.')).replace('.', '/')
+								+ ";";
+						}
+						String mappedName = resolver.mapFieldName(namespace, className, name, unMappedDesc);
+						if (f.getName().equals(mappedName)) {
+							return new LookupIntermediateArguments(lookup, owner, mappedName, type);
+						}
+					}
+				}
+			}
+		}
+
+		return new LookupIntermediateArguments(lookup, owner, name, type);
+	}
+
+	private static String mapMethodTypeDescriptor(String namespaceTo, MethodType type) {
+		String desc = type.toMethodDescriptorString();
+		MappingResolver resolver = QuiltLoader.getMappingResolver();
+
+		StringBuilder result = new StringBuilder();
+		int idxObjDescStart = -1;
+		int idxSemicolon = 0;
+		while ((idxObjDescStart = desc.indexOf('L', idxObjDescStart + 1)) >= 0) {
+			int previousSemicolon = idxSemicolon;
+			idxSemicolon = desc.indexOf(';', idxObjDescStart);
+			String sub = desc.substring(idxObjDescStart + 1, idxSemicolon).replace('/', '.');
+
+			result.append(desc.substring(previousSemicolon, idxObjDescStart + 1));
+			result.append(resolver.unmapClassName(namespaceTo, sub).replace('.', '/'));
+		}
+
+		if (idxSemicolon > 0) {
+			result.append(desc.substring(idxSemicolon));
+		}
+
+		if (result.length() == 0) {
+			return desc;
+		} else {
+			return result.toString();
+		}
+	}
+
+	public static LookupIntermediateArguments fixLookupFindMethod(Lookup lookup, Class<?> owner, String name,
+		MethodType type) {
+
+		MappingResolver resolver = QuiltLoader.getMappingResolver();
+
+		Collection<String> possibleNamespaces = new LinkedHashSet<>(resolver.getNamespaces());
+		possibleNamespaces.remove(resolver.getCurrentRuntimeNamespace());
+
+		for (Class<?> in : getMappableClassHierarchy(owner)) {
+			Lookup forTarget = lookup.in(in);
+			// Only return methods that the actual lookup is able to access
+			for (Method m : in.getDeclaredMethods()) {
+				if (m.getReturnType() != type.returnType() || !Arrays.equals(type.parameterArray(), m.getParameterTypes())) {
+					// Skip expensive name checking
+					continue;
+				}
+				// TODO: Handle modules
+				int mods = m.getModifiers() & (Opcodes.ACC_PUBLIC | Opcodes.ACC_PROTECTED | Opcodes.ACC_PRIVATE);
+				if (mods == 0) {
+					mods = MethodHandles.Lookup.PACKAGE;
+				}
+
+				if ((mods & forTarget.lookupModes()) != 0) {
+					// We can access the methods
+
+					for (String namespace : possibleNamespaces) {
+						String className = resolver.unmapClassName(namespace, in.getName());
+						String unMappedDesc = mapMethodTypeDescriptor(namespace, type);
+						String mappedName = resolver.mapMethodName(namespace, className, name, unMappedDesc);
+						if (m.getName().equals(mappedName)) {
+							return new LookupIntermediateArguments(lookup, owner, mappedName, type);
+						}
+					}
+				}
+			}
+		}
+
+		return new LookupIntermediateArguments(lookup, owner, name, type);
+	}
+
+	public static LookupIntermediateArguments fixLookupFindMethodSpecial(Lookup lookup, Class<?> owner, String name,
+		MethodType type, Class<?> specialCaller) {
+		LookupIntermediateArguments args = fixLookupFindMethod(lookup, owner, name, type);
+		args.specialCaller = specialCaller;
+		return args;
+	}
+}

--- a/src/main/java/org/quiltmc/loader/impl/transformer/QuiltTransformer.java
+++ b/src/main/java/org/quiltmc/loader/impl/transformer/QuiltTransformer.java
@@ -29,6 +29,7 @@ import org.quiltmc.loader.impl.game.MappingConfigurationImpl;
 import org.quiltmc.loader.impl.launch.common.QuiltLauncherBase;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
+import org.quiltmc.loader.impl.util.SystemProperties;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -42,6 +43,7 @@ final class QuiltTransformer {
 		boolean transformAccess = isGameClass && ((MappingConfigurationImpl) QuiltLauncherBase.getLauncher().getMappingConfiguration()).requiresPackageAccessHack();
 		boolean strip = !isGameClass || isDevelopment;
 		boolean applyAccessWidener = isGameClass && accessWidener.getTargets().contains(name);
+		boolean reflectiveFixes = !isGameClass;
 
 		if (!transformAccess && !strip && !applyAccessWidener) {
 			return bytes;
@@ -108,6 +110,11 @@ final class QuiltTransformer {
 
 		if (transformAccess) {
 			visitor = new PackageAccessFixer(QuiltLoaderImpl.ASM_VERSION, visitor);
+			visitorCount++;
+		}
+
+		if (reflectiveFixes && !Boolean.getBoolean(SystemProperties.DISABLE_REFLECTIVE_FIXES)) {
+			visitor = new ReflectiveFixer(QuiltLoaderImpl.ASM_VERSION, visitor);
 			visitorCount++;
 		}
 

--- a/src/main/java/org/quiltmc/loader/impl/transformer/ReflectiveFixer.java
+++ b/src/main/java/org/quiltmc/loader/impl/transformer/ReflectiveFixer.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2024 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.loader.impl.transformer;
+
+import java.lang.invoke.MethodHandles.Lookup;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
+import org.quiltmc.loader.impl.util.log.Log;
+import org.quiltmc.loader.impl.util.log.LogCategory;
+
+@QuiltLoaderInternal(QuiltLoaderInternalType.NEW_INTERNAL)
+class ReflectiveFixer extends ClassVisitor {
+
+	private static final String OWNER_CLASS = Type.getInternalName(Class.class);
+	private static final String OWNER_LOOKUP = Type.getInternalName(Lookup.class);
+
+	private static final String OWNER_REFLECTIVE_UTIL = Type.getInternalName(QuiltReflectiveFixUtil.class);
+	private static final String OWNER_REFLECTIVE_MTH = Type.getInternalName(
+		QuiltReflectiveFixUtil.MethodIntermediateArguments.class
+	);
+	private static final String OWNER_REFLECTIVE_TMP = Type.getInternalName(
+		QuiltReflectiveFixUtil.LookupIntermediateArguments.class
+	);
+
+	ReflectiveFixer(int api, ClassVisitor classVisitor) {
+		super(api, classVisitor);
+	}
+
+	@Override
+	public MethodVisitor visitMethod(int access, String name, String descriptor, String signature,
+		String[] exceptions) {
+
+		return new MethodVisitor(api, super.visitMethod(access, name, descriptor, signature, exceptions)) {
+
+			int stackIncrease = 0;
+
+			@Override
+			public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+
+				if (OWNER_CLASS.equals(owner)) {
+					if ("forName".equals(name)) {
+
+						switch (descriptor) {
+							case "(Ljava/lang/String;)Ljava/lang/Class;":// (String)
+							case "(Ljava/lang/Module;Ljava/lang/String;)Ljava/lang/String;": {// (Module, String)
+								super.visitMethodInsn(
+									Opcodes.INVOKESTATIC, OWNER_REFLECTIVE_UTIL, "fixClassName",
+									"(Ljava/lang/String;)Ljava/lang/String;", false
+								);
+								break;
+							}
+							case "(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;": {
+								// (String, boolean, ClassLoader)
+
+								// A fun dance
+
+								// [?, ?, ?, String, boolean, ClassLoader]
+								super.visitInsn(Opcodes.DUP_X2);
+								// [?, ?, ?, ClassLoader, String, boolean, ClassLoader]
+								super.visitInsn(Opcodes.POP);
+								// [?, ?, ?, ClassLoader, String, boolean]
+								super.visitInsn(Opcodes.DUP_X2);
+								// [?, ?, ?, boolean, ClassLoader, String, boolean]
+								super.visitInsn(Opcodes.POP);
+								// [?, ?, ?, boolean, ClassLoader, String]
+								super.visitMethodInsn(
+									Opcodes.INVOKESTATIC, OWNER_REFLECTIVE_UTIL, "fixClassName",
+									"(Ljava/lang/String;)Ljava/lang/String;", false
+								);
+								// [?, ?, ?, boolean, ClassLoader, String]
+								super.visitInsn(Opcodes.DUP_X2);
+								// [?, ?, ?, String, boolean, ClassLoader, String]
+								super.visitInsn(Opcodes.POP);
+								// [?, ?, ?, String, boolean, ClassLoader]
+								stackIncrease = Math.max(stackIncrease, 1);
+								break;
+							}
+							default: {
+								Log.warn(
+									LogCategory.GENERAL, "ReflectiveFixer: Unknown / new Class.forName descriptor: "
+										+ descriptor
+								);
+								break;
+							}
+						}
+					} else if ("getDeclaredField".equals(name)) {
+						// [..., Class, String]
+						super.visitInsn(Opcodes.SWAP);
+						// [..., String, Class]
+						super.visitInsn(Opcodes.DUP_X1);
+						// [..., Class, String, Class]
+						super.visitMethodInsn(
+							Opcodes.INVOKESTATIC, OWNER_REFLECTIVE_UTIL, "fixDeclaredFieldName",
+							"(Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/String;", false
+						);
+						// [..., Class, String]
+						stackIncrease = Math.max(stackIncrease, 1);
+					} else if ("getField".equals(name)) {
+						// [..., Class, String]
+						super.visitInsn(Opcodes.SWAP);
+						// [..., String, Class]
+						super.visitInsn(Opcodes.DUP_X1);
+						// [..., Class, String, Class]
+						super.visitMethodInsn(
+							Opcodes.INVOKESTATIC, OWNER_REFLECTIVE_UTIL, "fixFieldName",
+							"(Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/String;", false
+						);
+						// [..., Class, String]
+						stackIncrease = Math.max(stackIncrease, 1);
+					} else if ("getDeclaredMethod".equals(name)) {
+						// ... , Class, String, Class[]
+						super.visitMethodInsn(
+							Opcodes.INVOKESTATIC, OWNER_REFLECTIVE_UTIL, "fixDeclaredMethodName",
+							"(Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/Class;)L"
+							+ OWNER_REFLECTIVE_MTH
+							+ ";", false
+						);
+						// ... , TMP
+						super.visitInsn(Opcodes.DUP);
+						// ... , TMP, TMP
+						super.visitMethodInsn(
+							Opcodes.INVOKEVIRTUAL, OWNER_REFLECTIVE_MTH, "getOwner", "()Ljava/lang/Class;", false
+						);
+						// ... , TMP, Class
+						super.visitInsn(Opcodes.SWAP);
+						// ... , Class, TMP
+						super.visitInsn(Opcodes.DUP);
+						// ... , Class, TMP, TMP
+						super.visitMethodInsn(
+							Opcodes.INVOKEVIRTUAL, OWNER_REFLECTIVE_MTH, "getMethodName", "()Ljava/lang/String;", false
+						);
+						// ... , Class, TMP, String
+						super.visitInsn(Opcodes.SWAP);
+						// ... , Class, String, TMP
+						super.visitMethodInsn(
+							Opcodes.INVOKEVIRTUAL, OWNER_REFLECTIVE_MTH, "getArgs", "()[Ljava/lang/Class;", false
+						);
+						// ... , Class, String, Class[]
+					} else if ("getMethod".equals(name)) {
+						// ... , Class, String, Class[]
+						super.visitMethodInsn(
+							Opcodes.INVOKESTATIC, OWNER_REFLECTIVE_UTIL, "fixMethodName",
+							"(Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/Class;)L"
+							+ OWNER_REFLECTIVE_MTH
+							+ ";", false
+						);
+						// ... , TMP
+						super.visitInsn(Opcodes.DUP);
+						// ... , TMP, TMP
+						super.visitMethodInsn(
+							Opcodes.INVOKEVIRTUAL, OWNER_REFLECTIVE_MTH, "getOwner", "()Ljava/lang/Class;", false
+						);
+						// ... , TMP, Class
+						super.visitInsn(Opcodes.SWAP);
+						// ... , Class, TMP
+						super.visitInsn(Opcodes.DUP);
+						// ... , Class, TMP, TMP
+						super.visitMethodInsn(
+							Opcodes.INVOKEVIRTUAL, OWNER_REFLECTIVE_MTH, "getMethodName", "()Ljava/lang/String;", false
+						);
+						// ... , Class, TMP, String
+						super.visitInsn(Opcodes.SWAP);
+						// ... , Class, String, TMP
+						super.visitMethodInsn(
+							Opcodes.INVOKEVIRTUAL, OWNER_REFLECTIVE_MTH, "getArgs", "()[Ljava/lang/Class;", false
+						);
+						// ... , Class, String, Class[]
+					}
+				} else if (OWNER_LOOKUP.equals(owner)) {
+
+					switch (name) {
+						case "findClass": {
+							super.visitMethodInsn(
+								Opcodes.INVOKESTATIC, OWNER_REFLECTIVE_UTIL, "fixClassName",
+								"(Ljava/lang/String;)Ljava/lang/String;", false
+							);
+							// In theory we could check the lookup to make sure we have permission
+							// But that just seems unnecessary
+							break;
+						}
+						case "findGetter":
+						case "findSetter":
+						case "findVarHandle":
+						case "findStaticGetter":
+						case "findStaticSetter":
+						case "findStaticVarHandle": {
+							// All of these methods have the same args
+							// [..., Lookup, Class(owner), String(name), Class(type) ]
+							super.visitMethodInsn(
+								Opcodes.INVOKESTATIC, OWNER_REFLECTIVE_UTIL, "fixLookupFindField",
+								"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;)L" + OWNER_REFLECTIVE_TMP + ";",
+								false
+							);
+							// [..., TMP]
+							super.visitInsn(Opcodes.DUP);
+							// [..., TMP, TMP]
+							super.visitMethodInsn(
+								Opcodes.INVOKEVIRTUAL, OWNER_REFLECTIVE_TMP, "getLookup", "()Ljava/lang/invoke/MethodHandles$Lookup;", false
+							);
+							// [..., TMP, Lookup]
+							super.visitInsn(Opcodes.SWAP);
+							// [..., Lookup, TMP]
+							super.visitInsn(Opcodes.DUP);
+							// [..., Lookup, TMP, TMP]
+							super.visitMethodInsn(
+								Opcodes.INVOKEVIRTUAL, OWNER_REFLECTIVE_TMP, "getOwner", "()Ljava/lang/Class;", false
+							);
+							// [..., Lookup, TMP, Class(owner)]
+							super.visitInsn(Opcodes.SWAP);
+							// [..., Lookup, Class(owner), TMP]
+							super.visitInsn(Opcodes.DUP);
+							// [..., Lookup, Class(owner), TMP, TMP]
+							super.visitMethodInsn(
+								Opcodes.INVOKEVIRTUAL, OWNER_REFLECTIVE_TMP, "getName", "()Ljava/lang/String;", false
+							);
+							// [..., Lookup, Class(owner), TMP, String(name)]
+							super.visitInsn(Opcodes.SWAP);
+							// [..., Lookup, Class(owner), String(name), TMP]
+							super.visitMethodInsn(
+								Opcodes.INVOKEVIRTUAL, OWNER_REFLECTIVE_TMP, "getFieldType", "()Ljava/lang/Class;",
+								false
+							);
+							// [..., Lookup, Class(owner), String(name), Class(type)]
+							break;
+						}
+						case "findStatic":
+						case "findVirtual": {
+							// [..., Lookup, Class(owner), String(name), MethodType]
+							super.visitMethodInsn(
+								Opcodes.INVOKESTATIC, OWNER_REFLECTIVE_UTIL, "fixLookupFindMethod",
+								"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/invoke/MethodType;)L"
+									+ OWNER_REFLECTIVE_TMP + ";", false
+							);
+							// [..., TMP]
+							super.visitInsn(Opcodes.DUP);
+							// [..., TMP, TMP]
+							super.visitMethodInsn(
+								Opcodes.INVOKEVIRTUAL, OWNER_REFLECTIVE_TMP, "getLookup", "()Ljava/lang/invoke/MethodHandles$Lookup;", false
+							);
+							// [..., TMP, Lookup]
+							super.visitInsn(Opcodes.SWAP);
+							// [..., Lookup, TMP]
+							super.visitInsn(Opcodes.DUP);
+							// [..., Lookup, TMP, TMP]
+							super.visitMethodInsn(
+								Opcodes.INVOKEVIRTUAL, OWNER_REFLECTIVE_TMP, "getOwner", "()Ljava/lang/Class;", false
+							);
+							// [..., Lookup, TMP, Class(owner)]
+							super.visitInsn(Opcodes.SWAP);
+							// [..., Lookup, Class(owner), TMP]
+							super.visitInsn(Opcodes.DUP);
+							// [..., Lookup, Class(owner), TMP, TMP]
+							super.visitMethodInsn(
+								Opcodes.INVOKEVIRTUAL, OWNER_REFLECTIVE_TMP, "getName", "()Ljava/lang/String;", false
+							);
+							// [..., Lookup, Class(owner), TMP, String(name)]
+							super.visitInsn(Opcodes.SWAP);
+							// [..., Lookup, Class(owner), String(name), TMP]
+							super.visitMethodInsn(
+								Opcodes.INVOKEVIRTUAL, OWNER_REFLECTIVE_TMP, "getMethodType",
+								"()Ljava/lang/invoke/MethodType;", false
+							);
+							// [..., Lookup, Class(owner), String(name), MethodType]
+							break;
+						}
+						case "findSpecial": {
+							// [..., Lookup, Class(owner), String(name), MethodType, Class(special)]
+							super.visitMethodInsn(
+								Opcodes.INVOKESTATIC, OWNER_REFLECTIVE_UTIL, "fixLookupFindMethodSpecial",
+								"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/Class;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/Class;)L"
+									+ OWNER_REFLECTIVE_TMP + ";", false
+							);
+							// [..., TMP]
+							super.visitInsn(Opcodes.DUP);
+							// [..., TMP, TMP]
+							super.visitMethodInsn(
+								Opcodes.INVOKEVIRTUAL, OWNER_REFLECTIVE_TMP, "getLookup", "()Ljava/lang/invoke/MethodHandles$Lookup;", false
+							);
+							// [..., TMP, Lookup]
+							super.visitInsn(Opcodes.SWAP);
+							// [..., Lookup, TMP]
+							super.visitInsn(Opcodes.DUP);
+							// [..., Lookup, TMP, TMP]
+							super.visitMethodInsn(
+								Opcodes.INVOKEVIRTUAL, OWNER_REFLECTIVE_TMP, "getOwner", "()Ljava/lang/Class;", false
+							);
+							// [..., Lookup, TMP, Class(owner)]
+							super.visitInsn(Opcodes.SWAP);
+							// [..., Lookup, Class(owner), TMP]
+							super.visitInsn(Opcodes.DUP);
+							// [..., Lookup, Class(owner), TMP, TMP]
+							super.visitMethodInsn(
+								Opcodes.INVOKEVIRTUAL, OWNER_REFLECTIVE_TMP, "getName", "()Ljava/lang/String;", false
+							);
+							// [..., Lookup, Class(owner), TMP, String(name)]
+							super.visitInsn(Opcodes.SWAP);
+							// [..., Lookup, Class(owner), String(name), TMP]
+							super.visitInsn(Opcodes.DUP);
+							// [..., Lookup, Class(owner), String(name), TMP, TMP]
+							super.visitMethodInsn(
+								Opcodes.INVOKEVIRTUAL, OWNER_REFLECTIVE_TMP, "getMethodType",
+								"()Ljava/lang/invoke/MethodType;", false
+							);
+							// [..., Lookup, Class(owner), String(name), TMP, MethodType]
+							super.visitInsn(Opcodes.SWAP);
+							// [..., Lookup, Class(owner), String(name), MethodType, TMP]
+							super.visitMethodInsn(
+								Opcodes.INVOKEVIRTUAL, OWNER_REFLECTIVE_TMP, "getSpecialCaller",
+								"()Ljava/lang/Class;", false
+							);
+							// [..., Lookup, Class(owner), String(name), MethodType, Class(special)]
+							break;
+						}
+						default: {
+							break;
+						}
+					}
+				}
+
+				super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+			}
+
+			@Override
+			public void visitMaxs(int maxStack, int maxLocals) {
+				// Ideally we'd track the actual stack value to figure out if we truly need to increase it
+				// But this is *much* easier
+				super.visitMaxs(maxStack + stackIncrease, maxLocals);
+			}
+		};
+	}
+}

--- a/src/main/java/org/quiltmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/SystemProperties.java
@@ -113,6 +113,9 @@ public final class SystemProperties {
 	/** Enables saving of all patched classes for debug purposes. */
 	public static final String DEBUG_DUMP_PATCHED_CLASSES = "loader.debug.dump_patched_classes";
 
+	/** Prevents loader from transforming classes with ReflectiveFixer */
+	public static final String DISABLE_REFLECTIVE_FIXES = "loader.transform.reflective_fixes.disable";
+
 	// ##############
 	// # Validation #
 	// ##############

--- a/src/main/java/org/quiltmc/loader/impl/util/mappings/LazyMappingResolver.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/mappings/LazyMappingResolver.java
@@ -18,8 +18,9 @@
 package org.quiltmc.loader.impl.util.mappings;
 
 import java.util.Collection;
+import java.util.Set;
 import java.util.function.Supplier;
-
+import java.util.stream.Stream;
 
 import org.quiltmc.loader.api.MappingResolver;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;

--- a/src/main/java/org/quiltmc/loader/impl/util/mappings/QuiltMappingResolver.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/mappings/QuiltMappingResolver.java
@@ -20,9 +20,13 @@ package org.quiltmc.loader.impl.util.mappings;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import net.fabricmc.mappingio.tree.MappingTreeView;
+import net.fabricmc.mappingio.tree.MappingTreeView.ClassMappingView;
 
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
 


### PR DESCRIPTION
This currently handles class names with mixed mappings, so doing:

`Class.forName(ServerPlayerEntity.class.getName() + "$2");`

now works correctly even if the inner class has been mapped differently.

This also supports field and method lookups using `Class.get[Declared](Field/Method)`, as well as the `MethodHandle.Lookup` methods `find[Static](Getter/Setter/VarHandle), and `find(Static/Virtual/Special)`

This only works if the mappings are present for it - using proper names will never work outside of a development environment. In addition, we still encourage developers to use the MappingResolver to be sure the names will always be mapped correctly.

This commit also adds a somewhat unrelated change:

- Fixed InternalsHiderTransform always adding one to the maximum stack size of every single method.

(I hadn't checked the order that visitMaxs is called in - and since it must be called last, just before visitEnd, we can wait and see if we've needed to emit code that requires an additional stack element, whereas I previously thought it was called first)