### PR TITLE
 Allowed The (Knot) Launcher To Give The Intended Namespace 

### DIFF
--- a/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/MinecraftGameProvider.java
+++ b/minecraft/src/main/java/org/quiltmc/loader/impl/game/minecraft/MinecraftGameProvider.java
@@ -191,11 +191,6 @@ public class MinecraftGameProvider implements GameProvider {
 	}
 
 	@Override
-	public String getNamespace() {
-		return QuiltLauncherBase.getLauncher().isDevelopment() ? "named" : "intermediary";
-	}
-
-	@Override
 	public boolean requiresUrlClassLoader() {
 		return hasModLoader;
 	}
@@ -433,7 +428,7 @@ public class MinecraftGameProvider implements GameProvider {
 
 		setupLogHandler(launcher, true);
 
-		transformer.locateEntrypoints(launcher, getNamespace(), gameJars);
+		transformer.locateEntrypoints(launcher, QuiltLauncherBase.getLauncher().getTargetNamespace(), gameJars);
 	}
 
 	private void setupLogHandler(QuiltLauncher launcher, boolean useTargetCl) {

--- a/src/main/java/org/quiltmc/loader/impl/discovery/ClasspathModCandidateFinder.java
+++ b/src/main/java/org/quiltmc/loader/impl/discovery/ClasspathModCandidateFinder.java
@@ -173,7 +173,7 @@ public class ClasspathModCandidateFinder {
 
 	public static Path getGameProviderPath() {
 		try {
-			return UrlUtil.asPath(QuiltLoaderImpl.INSTANCE.getGameProvider().getClass().getProtectionDomain().getCodeSource().getLocation());
+			return UrlUtil.asPath(QuiltLoaderImpl.class.getProtectionDomain().getCodeSource().getLocation());
 		} catch (Throwable t) {
 			Log.debug(LogCategory.DISCOVERY, "Could not retrieve launcher code source!", t);
 			return null;

--- a/src/main/java/org/quiltmc/loader/impl/discovery/ClasspathModCandidateFinder.java
+++ b/src/main/java/org/quiltmc/loader/impl/discovery/ClasspathModCandidateFinder.java
@@ -173,7 +173,7 @@ public class ClasspathModCandidateFinder {
 
 	public static Path getGameProviderPath() {
 		try {
-			return UrlUtil.asPath(QuiltLoaderImpl.class.getProtectionDomain().getCodeSource().getLocation());
+			return UrlUtil.asPath(QuiltLoaderImpl.INSTANCE.getGameProvider().getClass().getProtectionDomain().getCodeSource().getLocation());
 		} catch (Throwable t) {
 			Log.debug(LogCategory.DISCOVERY, "Could not retrieve launcher code source!", t);
 			return null;

--- a/src/main/java/org/quiltmc/loader/impl/game/GameProvider.java
+++ b/src/main/java/org/quiltmc/loader/impl/game/GameProvider.java
@@ -44,9 +44,6 @@ public interface GameProvider {
 	String getEntrypoint();
 	Path getLaunchDirectory();
 	boolean isObfuscated();
-	default String getNamespace() {
-		return isObfuscated()? "intermediary": "named";
-	};
 	boolean requiresUrlClassLoader();
 
 	boolean isEnabled();

--- a/src/main/java/org/quiltmc/loader/impl/launch/common/MappingConfiguration.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/common/MappingConfiguration.java
@@ -103,12 +103,7 @@ public final class MappingConfiguration {
 	}
 
 	public String getTargetNamespace() {
-		GameProvider gameProvider = QuiltLoaderImpl.INSTANCE.tryGetGameProvider();
-		if (gameProvider != null)
-			return gameProvider.getNamespace();
-		// else
-		// If the game provider doesn't exist yet, use the development flag to set the namespace
-		return QuiltLauncherBase.getLauncher().isDevelopment() ? "named" : "intermediary";
+		return QuiltLauncherBase.getLauncher().getTargetNamespace();
 	}
 
 	public boolean requiresPackageAccessHack() {

--- a/src/main/java/org/quiltmc/loader/impl/launch/common/QuiltLauncher.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/common/QuiltLauncher.java
@@ -79,6 +79,7 @@ public interface QuiltLauncher {
 	String getEntrypoint();
 
 	String getTargetNamespace();
+	String getFinalNamespace();
 
 	List<Path> getClassPath();
 

--- a/src/main/java/org/quiltmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/knot/Knot.java
@@ -67,7 +67,7 @@ public class Knot extends QuiltLauncherBase {
 	private boolean isDevelopment;
 	private EnvType envType;
 	private final List<Path> classPath = new ArrayList<>();
-	private GameProvider provider;
+	protected GameProvider provider;
 	private boolean unlocked;
 
 	public static void launch(String[] args, EnvType type) {

--- a/src/main/java/org/quiltmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/knot/Knot.java
@@ -264,6 +264,10 @@ public final class Knot extends QuiltLauncherBase {
 		// TODO: Won't work outside of Yarn
 		return isDevelopment ? "named" : "intermediary";
 	}
+	@Override
+	public String getFinalNamespace() {
+		return "intermediary";
+	}
 
 	@Override
 	public List<Path> getClassPath() {

--- a/src/main/java/org/quiltmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/knot/Knot.java
@@ -60,7 +60,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 @QuiltLoaderInternal(QuiltLoaderInternalType.LEGACY_EXPOSED)
-public final class Knot extends QuiltLauncherBase {
+public class Knot extends QuiltLauncherBase {
 	protected Map<String, Object> properties = new HashMap<>();
 
 	private KnotClassLoaderInterface classLoader;

--- a/src/main/java/org/quiltmc/loader/impl/launch/knot/KnotClassDelegate.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/knot/KnotClassDelegate.java
@@ -62,11 +62,11 @@ import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
 @QuiltLoaderInternal(QuiltLoaderInternalType.LEGACY_EXPOSED)
-class KnotClassDelegate {
-	static class Metadata {
+public class KnotClassDelegate {
+	public static class Metadata {
 		static final Metadata EMPTY = new Metadata(null, null);
 
-		final Manifest manifest;
+		public final Manifest manifest;
 		final CodeSourceImpl codeSource;
 
 		Metadata(Manifest manifest, CodeSourceImpl codeSource) {
@@ -375,7 +375,7 @@ class KnotClassDelegate {
 		return hideReason != null ? hideReason : "";
 	}
 
-	Metadata getMetadata(String name, URL resourceURL) {
+	public Metadata getMetadata(String name, URL resourceURL) {
 		if (resourceURL == null) return Metadata.EMPTY;
 
 		String classFileName = LoaderUtil.getClassFileName(name);
@@ -434,7 +434,7 @@ class KnotClassDelegate {
 		});
 	}
 
-	Metadata getMetadata(URL codeSourceUrl) {
+	public Metadata getMetadata(URL codeSourceUrl) {
 		return metadataCache.computeIfAbsent(codeSourceUrl.toString(), (codeSourceStr) -> {
 			Manifest manifest = null;
 			CodeSourceImpl codeSource = null;
@@ -557,7 +557,7 @@ class KnotClassDelegate {
 		}
 	}
 
-	void setAllowedPrefixes(URL url, String... prefixes) {
+	public void setAllowedPrefixes(URL url, String... prefixes) {
 		if (prefixes.length == 0) {
 			allowedPrefixes.remove(url.toString());
 		} else {
@@ -565,11 +565,11 @@ class KnotClassDelegate {
 		}
 	}
 
-	void setTransformCache(URL insideTransformCache) {
+	public void setTransformCache(URL insideTransformCache) {
 		transformCacheUrl = insideTransformCache.toString();
 	}
 
-	void setHiddenClasses(Set<String> hiddenClasses) {
+	public void setHiddenClasses(Set<String> hiddenClasses) {
 		Map<String, String> map = new HashMap<>();
 		for (String cl : hiddenClasses) {
 			map.put(cl, "unknown reason");
@@ -577,15 +577,15 @@ class KnotClassDelegate {
 		setHiddenClasses(map);
 	}
 
-	void setHiddenClasses(Map<String, String> hiddenClasses) {
+	public void setHiddenClasses(Map<String, String> hiddenClasses) {
 		this.hiddenClasses = hiddenClasses;
 	}
 
-	void setPluginPackages(Map<String, ClassLoader> map) {
+	public void setPluginPackages(Map<String, ClassLoader> map) {
 		pluginPackages = map;
 	}
 
-	void hideParentUrl(URL parentPath) {
+	public void hideParentUrl(URL parentPath) {
 		parentHiddenUrls.add(parentPath.toString());
 	}
 }

--- a/src/main/java/org/quiltmc/loader/impl/launch/knot/KnotClassLoader.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/knot/KnotClassLoader.java
@@ -49,7 +49,7 @@ import java.util.List;
 import java.util.Objects;
 
 @QuiltLoaderInternal(QuiltLoaderInternalType.LEGACY_EXPOSED)
-class KnotClassLoader extends SecureClassLoader implements KnotClassLoaderInterface {
+public class KnotClassLoader extends SecureClassLoader implements KnotClassLoaderInterface {
 	private static class DynamicURLClassLoader extends URLClassLoader {
 		private DynamicURLClassLoader(URL[] urls) {
 			super(urls, new DummyClassLoader());
@@ -71,7 +71,7 @@ class KnotClassLoader extends SecureClassLoader implements KnotClassLoaderInterf
 	private final ClassLoader originalLoader;
 	private final KnotClassDelegate delegate;
 
-	KnotClassLoader(boolean isDevelopment, EnvType envType, GameProvider provider) {
+	public KnotClassLoader(boolean isDevelopment, EnvType envType, GameProvider provider) {
 		super(new DynamicURLClassLoader(new URL[0]));
 		this.originalLoader = getClass().getClassLoader();
 		// For compatibility we send all URLs to the fake loader

--- a/src/main/java/org/quiltmc/loader/impl/launch/knot/KnotClassLoaderInterface.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/knot/KnotClassLoaderInterface.java
@@ -26,8 +26,8 @@ import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
 
 @QuiltLoaderInternal(QuiltLoaderInternalType.LEGACY_EXPOSED)
-interface KnotClassLoaderInterface extends KnotBaseClassLoader {
-	KnotClassDelegate getDelegate();
+public interface KnotClassLoaderInterface extends KnotBaseClassLoader {
+	public KnotClassDelegate getDelegate();
 	ClassLoader getOriginalLoader();
 	boolean isClassLoaded(String name);
 	Class<?> loadIntoTarget(String name) throws ClassNotFoundException;

--- a/src/main/java/org/quiltmc/loader/impl/launch/knot/KnotCompatibilityClassLoader.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/knot/KnotCompatibilityClassLoader.java
@@ -34,10 +34,10 @@ import java.nio.file.Path;
 import java.security.CodeSource;
 
 @QuiltLoaderInternal(QuiltLoaderInternalType.LEGACY_EXPOSED)
-class KnotCompatibilityClassLoader extends URLClassLoader implements KnotClassLoaderInterface {
+public class KnotCompatibilityClassLoader extends URLClassLoader implements KnotClassLoaderInterface {
 	private final KnotClassDelegate delegate;
 
-	KnotCompatibilityClassLoader(boolean isDevelopment, EnvType envType, GameProvider provider) {
+	public KnotCompatibilityClassLoader(boolean isDevelopment, EnvType envType, GameProvider provider) {
 		super(new URL[0], KnotCompatibilityClassLoader.class.getClassLoader());
 		this.delegate = new KnotClassDelegate(isDevelopment, envType, this, provider);
 	}

--- a/src/main/java/org/quiltmc/loader/impl/transformer/RuntimeModRemapper.java
+++ b/src/main/java/org/quiltmc/loader/impl/transformer/RuntimeModRemapper.java
@@ -74,7 +74,7 @@ final class RuntimeModRemapper {
 		QuiltLauncher launcher = QuiltLauncherBase.getLauncher();
 
 		TinyRemapper remapper = TinyRemapper.newRemapper()
-				.withMappings(TinyUtils.createMappingProvider(launcher.getMappingConfiguration().getMappings(), "intermediary", launcher.getTargetNamespace()))
+				.withMappings(TinyUtils.createMappingProvider(launcher.getMappingConfiguration().getMappings(), launcher.getFinalNamespace(), launcher.getTargetNamespace()))
 				.renameInvalidLocals(false)
 				.extension(new MixinExtension(remapMixins::contains))
 				.build();
@@ -167,9 +167,9 @@ final class RuntimeModRemapper {
 
 	private static byte[] remapAccessWidener(byte[] input, Remapper remapper) {
 		AccessWidenerWriter writer = new AccessWidenerWriter();
-		AccessWidenerRemapper remappingDecorator = new AccessWidenerRemapper(writer, remapper, "intermediary", QuiltLauncherBase.getLauncher().getTargetNamespace());
+		AccessWidenerRemapper remappingDecorator = new AccessWidenerRemapper(writer, remapper, QuiltLauncherBase.getLauncher().getFinalNamespace(), QuiltLauncherBase.getLauncher().getTargetNamespace());
 		AccessWidenerReader accessWidenerReader = new AccessWidenerReader(remappingDecorator);
-		accessWidenerReader.read(input, "intermediary");
+		accessWidenerReader.read(input, QuiltLauncherBase.getLauncher().getFinalNamespace());
 		return writer.write();
 	}
 


### PR DESCRIPTION
Continuation of https://github.com/QuiltMC/quilt-loader/pull/435. Now moved under the CRModders namespace.

<br/>

Adds a `getFinalNamespace()` to the `QuiltLauncher` allowing the knot to provide other namespaces outside of `intermediary` to be used.
Currently, the access widener's namespace preference is hardcoded as `intermediary` within the `RuntimeModRemapper`, but with this change the value is now gotten from the launcher.

This PR also makes several functions and classes for the knot class loaders public, allowing for the creation of other knots.