### PR TITLE
Generate a Multi-Release jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -187,11 +187,16 @@ task fatJar(type: ShadowJar, dependsOn: getSat4jAbout) {
 		rename { "${it}_${project.archivesBaseName}"}
 	}
 
+	into("META-INF/versions/11") {
+		from project(":java11").sourceSets.main.output
+	}
+
 	manifest {
 		attributes (
 			"Main-Class": "net.fabricmc.loader.launch.server.FabricServerLauncher",
 			"Fabric-Loom-Remap": "false",
-			"Automatic-Module-Name": "org.quiltmc.loader"
+			"Automatic-Module-Name": "org.quiltmc.loader",
+			"Multi-Release": "true"
 		)
 	}
 

--- a/java11/build.gradle
+++ b/java11/build.gradle
@@ -1,0 +1,27 @@
+java {
+	toolchain {
+		languageVersion.set(JavaLanguageVersion.of(11))
+	}
+}
+
+dependencies {
+	implementation project(':dependencies')
+	implementation project(path: ':dependencies', configuration: 'include')
+	implementation project(":")
+}
+
+sourceSets {
+	main {
+		java {
+
+		}
+	}
+}
+
+tasks.withType(JavaCompile).configureEach {
+	it.options.encoding = "UTF-8"
+}
+
+jar {
+	enabled = false
+}

--- a/java11/src/main/java/org/quiltmc/loader/impl/util/JavaVersionUtil.java
+++ b/java11/src/main/java/org/quiltmc/loader/impl/util/JavaVersionUtil.java
@@ -21,9 +21,6 @@ package org.quiltmc.loader.impl.util;
 public final class JavaVersionUtil {
 
     public static int getJavaVersion() {
-        if (true) {
-            throw new Error("Success! This means that the multi-release-jar is working!");
-        }
         return Runtime.version().feature();
     }
 }

--- a/java11/src/main/java/org/quiltmc/loader/impl/util/JavaVersionUtil.java
+++ b/java11/src/main/java/org/quiltmc/loader/impl/util/JavaVersionUtil.java
@@ -20,30 +20,10 @@ package org.quiltmc.loader.impl.util;
 @QuiltLoaderInternal(QuiltLoaderInternalType.NEW_INTERNAL)
 public final class JavaVersionUtil {
 
-	private static int JAVA_VERSION = -1;
-
-	public static int getJavaVersion() {
-		if (JAVA_VERSION < 0) {
-			String jVersion = System.getProperty("java.version", "");
-			if (jVersion.startsWith("1.")) {
-				// Java 8 or earlier
-				// However loader itself requires java 8, so just force java 8
-				JAVA_VERSION = 8;
-			} else {
-				int firstDot = jVersion.indexOf('.');
-				if (firstDot > 0) {
-					jVersion = jVersion.substring(0, firstDot);
-				}
-				try {
-					JAVA_VERSION = Integer.parseInt(jVersion);
-				} catch (NumberFormatException nfe) {
-					throw new IllegalStateException(
-						"Unable to convert 'java.version' (" + jVersion + ") into a version number!", nfe
-					);
-				}
-			}
-		}
-
-		return JAVA_VERSION;
-	}
+    public static int getJavaVersion() {
+        if (true) {
+            throw new Error("Success! This means that the multi-release-jar is working!");
+        }
+        return Runtime.version().feature();
+    }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,3 +23,4 @@ include "minecraft"
 include "minecraft:minecraft-test"
 include 'junit'
 include 'dependencies'
+include 'java11'

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -296,7 +296,6 @@ public final class QuiltLoaderImpl {
 	}
 
 	public void load() {
-		JavaVersionUtil.getJavaVersion();
 		if (provider == null) throw new IllegalStateException("game provider not set");
 		if (frozen) throw new IllegalStateException("Frozen - cannot load additional mods!");
 

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -112,6 +112,7 @@ import org.quiltmc.loader.impl.util.DefaultLanguageAdapter;
 import org.quiltmc.loader.impl.util.FileHasherImpl;
 import org.quiltmc.loader.impl.util.FilePreloadHelper;
 import org.quiltmc.loader.impl.util.HashUtil;
+import org.quiltmc.loader.impl.util.JavaVersionUtil;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
 import org.quiltmc.loader.impl.util.SystemProperties;
@@ -295,6 +296,7 @@ public final class QuiltLoaderImpl {
 	}
 
 	public void load() {
+		JavaVersionUtil.getJavaVersion();
 		if (provider == null) throw new IllegalStateException("game provider not set");
 		if (frozen) throw new IllegalStateException("Frozen - cannot load additional mods!");
 

--- a/src/main/java/org/quiltmc/loader/impl/util/MultiReleaseJarCandidate.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/MultiReleaseJarCandidate.java
@@ -23,7 +23,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /** Indicates to future quilt maintainers that the class is intended to be converted to a Multi-Release jar after we add
- * support for it, and then this annotation should be deleted.
+ * support for it, and then this annotation should be replaced with {@link MultiReleaseJarModified}.
  * <p>
  * (This merely allows for this to be searched) */
 @QuiltLoaderInternal(QuiltLoaderInternalType.NEW_INTERNAL)

--- a/src/main/java/org/quiltmc/loader/impl/util/MultiReleaseJarModified.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/MultiReleaseJarModified.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.loader.impl.util;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/** Indicates that the annotated class has additional implementations in the various javaXX subprojects, and so changes
+ * to the annotated class (such as new methods or fields) must be propagated to those additional subprojects. */
+@QuiltLoaderInternal(QuiltLoaderInternalType.NEW_INTERNAL)
+@Retention(SOURCE)
+@Target(TYPE)
+public @interface MultiReleaseJarModified {
+
+}


### PR DESCRIPTION
This will allow us to have better implementations of existing features where newer versions of java has a better API.

For now this just replaces `JavaVersionUtil.getJavaVersion()` with a call to the public API `Runtime.Version`, rather than the current brittle string parser