### PR TITLE
Fix Mojang mods not running on a Mojang environment

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/transformer/RuntimeModRemapper.java
+++ b/src/main/java/org/quiltmc/loader/impl/transformer/RuntimeModRemapper.java
@@ -89,9 +89,15 @@ final class RuntimeModRemapper {
 			return;
 		}
 
+		boolean mojmapEnvironment = "mojang".equals(mappingConfiguration.getTargetNamespace());
+
 		for (ModLoadOption mod : mods) {
 			String namespace = mod.namespaceMappingFrom();
 			if ("mojang".equals(namespace)) {
+				if (mojmapEnvironment) {
+					break;
+				}
+
 				throw new UnsupportedOperationException("Cannot remap mojang mods to another environment!");
 			}
 			if (namespace != null) {


### PR DESCRIPTION
This has been tested with a hacked-together mod I made (it's called Ok Zoomer: Mojmap Edition!)

This skips the remapping of Mojmap mods if the environment is Mojang 