### PR TITLE
add system property for enabling the package access hack

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/game/MappingConfigurationImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/game/MappingConfigurationImpl.java
@@ -60,6 +60,8 @@ import org.quiltmc.loader.impl.util.mappings.FilteringMappingVisitor;
 // this implementation is intended specifically for use by the Minecraft game provider
 @QuiltLoaderInternal(QuiltLoaderInternalType.LEGACY_EXPOSED)
 public class MappingConfigurationImpl implements MappingConfiguration {
+	private static final boolean FIX_PACKAGE_ACCESS = System.getProperty(SystemProperties.FIX_PACKAGE_ACCESS) != null;
+
 	private boolean initialized;
 
 	private String gameId;
@@ -118,7 +120,7 @@ public class MappingConfigurationImpl implements MappingConfiguration {
 	}
 
 	public boolean requiresPackageAccessHack() {
-		return getTargetNamespace().equals("named");
+		return FIX_PACKAGE_ACCESS || getTargetNamespace().equals("named");
 	}
 
 	private void initialize() {

--- a/src/main/java/org/quiltmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/SystemProperties.java
@@ -62,6 +62,8 @@ public final class SystemProperties {
 	public static final String ADD_MODS = "loader.addMods";
 	// class path groups to map multiple class path entries to a mod (paths separated by path separator, groups by double path separator)
 	public static final String PATH_GROUPS = "loader.classPathGroups";
+	// enable the fixing of package access errors in the game jar(s)
+	public static final String FIX_PACKAGE_ACCESS = "loader.fixPackageAccess";
 	// system level libraries, matching code sources will not be assumed to be part of the game or mods and remain on the system class path (paths separated by path separator)
 	public static final String SYSTEM_LIBRARIES = "loader.systemLibraries";
 	public static final String DISABLE_FORKED_GUIS = "loader.disable_forked_guis";


### PR DESCRIPTION
this has been in Fabric Loader since 0.16, and at Ornithe we requires it for our new intermediary