### PR TITLE
Don't remap mods that are already in the target namespace

### DIFF
--- a/src/main/java/org/quiltmc/loader/impl/transformer/RuntimeModRemapper.java
+++ b/src/main/java/org/quiltmc/loader/impl/transformer/RuntimeModRemapper.java
@@ -100,14 +100,14 @@ final class RuntimeModRemapper {
 
 				throw new UnsupportedOperationException("Cannot remap mojang mods to another environment!");
 			}
-			if (namespace != null) {
+			if (namespace != null && !namespace.equals(mappingConfiguration.getTargetNamespace())) {
 				modsToRemap.add(mod);
 			}
 		}
 	}
 
-	public boolean doesModNeedRemapping(ModLoadOption mod) {
-		return modsToRemap.contains(mod);
+	public boolean modNeedsRemapping(ModLoadOption mod) {
+		return mod.namespaceMappingFrom() != null && !mod.namespaceMappingFrom().equals(QuiltLauncherBase.getLauncher().getMappingConfiguration().getTargetNamespace());
 	}
 
 	public void remap(TransformCache cache) {

--- a/src/main/java/org/quiltmc/loader/impl/transformer/TransformCache.java
+++ b/src/main/java/org/quiltmc/loader/impl/transformer/TransformCache.java
@@ -126,7 +126,7 @@ class TransformCache {
 					}
 
 					// copy classes for mods which don't need remapped
-					if (!remapper.doesModNeedRemapping(mod)) {
+					if (!remapper.modNeedsRemapping(mod)) {
 						try (Stream<Path> stream = Files.walk(modSrc)) {
 							stream
 								.filter(FasterFiles::isRegularFile)
@@ -134,7 +134,7 @@ class TransformCache {
 								.forEach(path -> copyFile(path, modSrc, modDst));
 						}
 					}
-				} else if (remapper.doesModNeedRemapping(mod)) {
+				} else if (remapper.modNeedsRemapping(mod)) {
 					// Copy everything that isn't a class file, since those get remapped
 					try (Stream<Path> stream = Files.walk(modSrc)) {
 						stream


### PR DESCRIPTION
We shouldn't be running TinyRemapper to remap intermediary mods to intermediary! That's silly! This fixes that oversight.

This would fix #482.