### PR TITLE
Downstream fabric 0.19.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,9 @@ javaComponent.withVariantsFromConfiguration(configurations.shadowRuntimeElements
 
 test {
 	useJUnitPlatform()
+	testLogging { 
+		exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL 
+         }
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ test {
 	useJUnitPlatform()
 	testLogging { 
 		exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL 
-         }
+	}
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,4 +27,4 @@ annotations = 24.0.1
 junit_bom = 5.9.3
 github_api = 1.315
 flexver = 1.1.0
-mixin_extras = 0.5.4
+mixin_extras = 0.5.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ group = org.quiltmc
 description = The mod loading component of Quilt
 url = https://github.com/quiltmc/quilt-loader
 # Don't forget to change this in QuiltLoaderImpl as well
-quilt_loader = 0.30.1
+quilt_loader = 0.30.2-beta.1
 
 # Fabric & Quilt Libraries
 asm = 9.10.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,11 +9,11 @@ quilt_loader = 0.30.1-beta.3
 
 # Fabric & Quilt Libraries
 asm = 9.10.1
-sponge_mixin = 0.17.3+mixin.0.8.7
+sponge_mixin = 0.17.4+mixin.0.8.7
 tiny_mappings_parser = 0.3.0+build.17
-tiny_remapper = 0.14.0
+tiny_remapper = 0.14.1
 class_tweaker = 0.3.0-beta.2
-mapping_io = 0.7.1
+mapping_io = 0.9.1
 quilt_json5 = 1.0.4+final
 quilt_parsers = 0.3.1
 quilt_loader_sat4j = 2.3.5.1

--- a/src/fabric/api/java/net/fabricmc/loader/api/LanguageAdapter.java
+++ b/src/fabric/api/java/net/fabricmc/loader/api/LanguageAdapter.java
@@ -27,11 +27,11 @@ import net.fabricmc.loader.impl.util.DefaultLanguageAdapter;
  *
  * <p>A language adapter is defined as so in {@code fabric.mod.json}:
  * <pre><blockquote>
- *   "languageAdapter": {
+ *   "languageAdapters": {
  *     "&lt;a key&gt;": "&lt;the binary name of the language adapter class&gt;"
  *   }
  * </blockquote></pre>
- * Multiple keys can be present in the {@code languageAdapter} section.</p>
+ * Multiple keys can be present in the {@code languageAdapters} section.</p>
  *
  * <p>In the declaration, the language adapter is referred by its <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-13.html#jls-13.1">binary name</a>,
  * such as {@code "mypackage.MyClass$Inner"}. It must have a no-argument public constructor for the Loader to instantiate.</p>

--- a/src/main/java/org/quiltmc/loader/api/LanguageAdapter.java
+++ b/src/main/java/org/quiltmc/loader/api/LanguageAdapter.java
@@ -26,11 +26,11 @@ import org.quiltmc.loader.impl.util.DefaultLanguageAdapter;
  *
  * <p>A language adapter is defined as so in {@code fabric.mod.json}:
  * <pre><blockquote>
- *   "languageAdapter": {
+ *   "languageAdapters": {
  *     "&lt;a key&gt;": "&lt;the binary name of the language adapter class&gt;"
  *   }
  * </blockquote></pre>
- * Multiple keys can be present in the {@code languageAdapter} section.</p>
+ * Multiple keys can be present in the {@code languageAdapters} section.</p>
  *
  * <p>In the declaration, the language adapter is referred by its <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-13.html#jls-13.1">binary name</a>,
  * such as {@code "mypackage.MyClass$Inner"}. It must have a no-argument public constructor for the Loader to instantiate.</p>

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -131,7 +131,7 @@ public final class QuiltLoaderImpl {
 
 	public static final int ASM_VERSION = Opcodes.ASM9;
 
-	public static final String VERSION = "0.30.1";
+	public static final String VERSION = "0.30.2-beta.1";
 	public static final String MOD_ID = "quilt_loader";
 	public static final String DEFAULT_MODS_DIR = "mods";
 	public static final String DEFAULT_CACHE_DIR = ".cache";

--- a/src/main/java/org/quiltmc/loader/impl/fabric/util/version/VersionPredicateParser.java
+++ b/src/main/java/org/quiltmc/loader/impl/fabric/util/version/VersionPredicateParser.java
@@ -28,6 +28,7 @@ import org.quiltmc.loader.api.VersionFormatException;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
 
+import net.fabricmc.loader.impl.util.version.SemanticVersionImpl;
 import net.fabricmc.loader.api.SemanticVersion;
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.VersionParsingException;
@@ -40,7 +41,15 @@ import net.fabricmc.loader.api.metadata.version.VersionPredicate.PredicateTerm;
 public final class VersionPredicateParser {
 	private static final VersionComparisonOperator[] OPERATORS = VersionComparisonOperator.values();
 
+	public static VersionPredicate any() {
+		return AnyVersionPredicate.INSTANCE;
+	}
+
 	public static VersionPredicate parse(String predicate) throws VersionParsingException {
+		if (predicate.isEmpty() || predicate.equals("*")) {
+			return AnyVersionPredicate.INSTANCE;
+		}
+
 		List<SingleVersionPredicate> predicateList = new ArrayList<>();
 
 		for (String s : predicate.split(" ")) {
@@ -76,13 +85,6 @@ public final class VersionPredicateParser {
 						throw new VersionParsingException("Invalid predicate: "+predicate+", version ranges with wildcards (.X) require using the equality operator or no operator at all!");
 					}
 
-					assert !semVer.getPrereleaseKey().isPresent();
-
-					int compCount = semVer.getVersionComponentCount();
-					assert compCount == 2 || compCount == 3;
-
-					operator = compCount == 2 ? VersionComparisonOperator.SAME_TO_NEXT_MAJOR : VersionComparisonOperator.SAME_TO_NEXT_MINOR;
-
 					int[] newComponents = new int[semVer.getVersionComponentCount() - 1];
 
 					for (int i = 0; i < semVer.getVersionComponentCount() - 1; i++) {
@@ -94,9 +96,28 @@ public final class VersionPredicateParser {
 					} catch (VersionFormatException e) {
 						throw new IllegalStateException("Failed to reconstruct a version from " + version, e);
 					}
+
+					
+					int compCount = semVer.getVersionComponentCount();
+
+					if (compCount <= 1) {
+						throw new IllegalStateException("invalid component count " + compCount + " for version " + semVer);
+					} else if (compCount <= 3) { // 2, 3 -> represent a.x as ^a-, a.b.x as ~a.b-
+						operator = compCount == 2 ? VersionComparisonOperator.SAME_TO_NEXT_MAJOR : VersionComparisonOperator.SAME_TO_NEXT_MINOR;
+					} else { // > 3 -> represent a.b.c.x as >=a.b.c- <a.b.(c+1)-
+						// generate two predicates for the bounds by adding the first to the list in this block
+						predicateList.add(new SingleVersionPredicate(VersionComparisonOperator.GREATER_EQUAL, version));
+
+						newComponents = newComponents.clone();
+						newComponents[newComponents.length - 1]++;
+						version = new SemanticVersionImpl(newComponents, "", null);
+						operator = VersionComparisonOperator.LESS;
+					}
+
+					// version, operator are being used later
 				}
 			} else if (!operator.isMinInclusive() && !operator.isMaxInclusive()) { // non-semver without inclusive bound
-				throw new VersionParsingException("Invalid predicate: "+predicate+", version ranges need to be semantic version compatible to use operators that exclude the bound!");
+				throw new VersionParsingException("Invalid predicate: " + predicate + ", version ranges need to be semantic version compatible to use operators that exclude the bound!");
 			} else { // non-semver with inclusive bound
 				operator = VersionComparisonOperator.EQUAL;
 			}

--- a/src/main/java/org/quiltmc/loader/impl/launch/common/QuiltMixinVersions.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/common/QuiltMixinVersions.java
@@ -38,6 +38,7 @@ public class QuiltMixinVersions {
 		// maximum loader version and bundled fabric mixin version, DESCENDING ORDER, LATEST FIRST
 		// loader versions with new mixin versions need to be added here
 
+		addVersion("0.19.4", "<quilt version>", FabricUtil.COMPATIBILITY_0_17_4);
 		addVersion("0.19.0", "0.31.0-beta.1", FabricUtil.COMPATIBILITY_0_17_1);
 		addVersion("0.18.4", "0.30.0-beta.2", FabricUtil.COMPATIBILITY_0_17_0);
 		addVersion("0.17.3", "0.29.3-beta.1", FabricUtil.COMPATIBILITY_0_16_5);

--- a/src/main/java/org/quiltmc/loader/impl/launch/common/QuiltMixinVersions.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/common/QuiltMixinVersions.java
@@ -38,7 +38,7 @@ public class QuiltMixinVersions {
 		// maximum loader version and bundled fabric mixin version, DESCENDING ORDER, LATEST FIRST
 		// loader versions with new mixin versions need to be added here
 
-		addVersion("0.19.4", "<quilt version>", FabricUtil.COMPATIBILITY_0_17_4);
+		addVersion("0.19.4", "0.30.2-beta.1", FabricUtil.COMPATIBILITY_0_17_4);
 		addVersion("0.19.0", "0.30.0-beta.8", FabricUtil.COMPATIBILITY_0_17_1);
 		addVersion("0.18.4", "0.30.0-beta.2", FabricUtil.COMPATIBILITY_0_17_0);
 		addVersion("0.17.3", "0.29.3-beta.1", FabricUtil.COMPATIBILITY_0_16_5);

--- a/src/main/java/org/quiltmc/loader/impl/transformer/QuiltTransformer.java
+++ b/src/main/java/org/quiltmc/loader/impl/transformer/QuiltTransformer.java
@@ -38,11 +38,13 @@ import org.objectweb.asm.ClassWriter;
 
 @QuiltLoaderInternal(QuiltLoaderInternalType.NEW_INTERNAL)
 final class QuiltTransformer {
+	private static final boolean DISABLE_ENVIRONMENT_STRIP = SystemProperties.getBoolean(SystemProperties.DISABLE_ENVIRONMENT_STRIP);
+
 	public static byte @Nullable [] transform(boolean isDevelopment, EnvType envType, TransformCache cache, ClassTweaker classTweaker, String name, ModLoadOption mod, byte[] bytes) {
 		GameProvider gameProvider = QuiltLoaderImpl.INSTANCE.getGameProvider();
 		boolean isGameClass = mod.id().equals(gameProvider.getGameId());
 		boolean transformAccess = isGameClass && gameProvider.requiresPackageAccessFix();
-		boolean strip = !isGameClass || isDevelopment;
+		boolean strip = (!isGameClass || isDevelopment) && !DISABLE_ENVIRONMENT_STRIP;
 		boolean applyClassTweaker = isGameClass && classTweaker.getTargets().contains(name.replace('.', '/'));
 		boolean reflectiveFixes = !isGameClass && !Boolean.getBoolean(SystemProperties.DISABLE_REFLECTIVE_FIXES);
 

--- a/src/main/java/org/quiltmc/loader/impl/transformer/QuiltTransformer.java
+++ b/src/main/java/org/quiltmc/loader/impl/transformer/QuiltTransformer.java
@@ -38,7 +38,7 @@ import org.objectweb.asm.ClassWriter;
 
 @QuiltLoaderInternal(QuiltLoaderInternalType.NEW_INTERNAL)
 final class QuiltTransformer {
-	private static final boolean DISABLE_ENVIRONMENT_STRIP = SystemProperties.getBoolean(SystemProperties.DISABLE_ENVIRONMENT_STRIP);
+	private static final boolean DISABLE_ENVIRONMENT_STRIP = SystemProperties.getBoolean(SystemProperties.DISABLE_ENVIRONMENT_STRIP, false);
 
 	public static byte @Nullable [] transform(boolean isDevelopment, EnvType envType, TransformCache cache, ClassTweaker classTweaker, String name, ModLoadOption mod, byte[] bytes) {
 		GameProvider gameProvider = QuiltLoaderImpl.INSTANCE.getGameProvider();

--- a/src/main/java/org/quiltmc/loader/impl/util/SystemProperties.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/SystemProperties.java
@@ -66,6 +66,8 @@ public final class SystemProperties {
 	public static final String PATH_GROUPS = "loader.classPathGroups";
 	// enable the fixing of package access errors in the game jar(s)
 	public static final String FIX_PACKAGE_ACCESS = "loader.fixPackageAccess";
+	// disable the stripping of environment code
+	public static final String DISABLE_ENVIRONMENT_STRIP = "loader.disableEnvironmentStrip";
 	// system level libraries, matching code sources will not be assumed to be part of the game or mods and remain on the system class path (paths separated by path separator)
 	public static final String SYSTEM_LIBRARIES = "loader.systemLibraries";
 	// whether to disable the swing gui popup when error occurred

--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -22,7 +22,7 @@
     "provides": [
         {
           "id": "fabricloader",
-          "version": "0.19.3"
+          "version": "0.19.5"
         }
       ],
       "depends": [


### PR DESCRIPTION
I didn't do the tests ([6ddfc3b](https://github.com/FabricMC/fabric-loader/commit/6ddfc3bc4b663c79d121d3c69312ba5ecfb872ac)) and left for you to bump the quilt version. Also don't forget to add the new version in `impl/launch/common/QuiltMixinVersions.java:line41`. Finally, I managed to pull off [dc09edc](https://github.com/FabricMC/fabric-loader/commit/dc09edc5c0cccfed0c5247b9b6c06877c640b5c2) which I initially said I couldn't do. Unfortunately, though, I wasn't able to implement [69d725e](https://github.com/FabricMC/fabric-loader/commit/69d725e9626f46646fc9526b8632511ba0040364) with my current knowledge. I tried a lot but I couldn't. Anyway, I am keeping this PR as draft to allow you to add whatever is left in the same commit unless you explicitly tell me not to. Have a nice day!