### PR TITLE
Loader plugins cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,9 @@ javaComponent.withVariantsFromConfiguration(configurations.shadowRuntimeElements
 
 test {
 	useJUnitPlatform()
+	testLogging {
+		exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+	}
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ group = org.quiltmc
 description = The mod loading component of Quilt
 url = https://github.com/quiltmc/quilt-loader
 # Don't forget to change this in QuiltLoaderImpl as well
-quilt_loader = 0.30.2-beta.1
+quilt_loader = 0.31.0-beta.1
 
 # Fabric & Quilt Libraries
 asm = 9.10.1

--- a/src/main/java/org/quiltmc/loader/api/plugin/ModMetadataExt.java
+++ b/src/main/java/org/quiltmc/loader/api/plugin/ModMetadataExt.java
@@ -17,15 +17,12 @@
 package org.quiltmc.loader.api.plugin;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
-import org.quiltmc.loader.api.LanguageAdapter;
 import org.quiltmc.loader.api.ModMetadata;
 import org.quiltmc.loader.api.ModMetadataToBeMovedToPlugins;
-import org.quiltmc.loader.api.Version;
 import org.quiltmc.loader.api.plugin.solver.LoadOption;
 import org.quiltmc.loader.api.plugin.solver.Rule;
 import org.quiltmc.loader.impl.metadata.qmj.AdapterLoadableClassEntry;

--- a/src/main/java/org/quiltmc/loader/api/plugin/QuiltLoaderPlugin.java
+++ b/src/main/java/org/quiltmc/loader/api/plugin/QuiltLoaderPlugin.java
@@ -22,18 +22,17 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.jetbrains.annotations.Nullable;
 import org.quiltmc.loader.api.LoaderValue;
 import org.quiltmc.loader.api.QuiltLoader;
+import org.quiltmc.loader.api.gui.QuiltTreeNode;
 import org.quiltmc.loader.api.plugin.gui.PluginGuiTreeNode;
 import org.quiltmc.loader.api.plugin.solver.LoadOption;
 import org.quiltmc.loader.api.plugin.solver.ModLoadOption;
 import org.quiltmc.loader.api.plugin.solver.ModSolveResult;
 import org.quiltmc.loader.api.plugin.solver.Rule;
 import org.quiltmc.loader.api.plugin.solver.TentativeLoadOption;
-import org.quiltmc.loader.impl.plugin.QuiltPluginManagerImpl;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
 
@@ -80,45 +79,74 @@ public interface QuiltLoaderPlugin {
 	 * {@link QuiltPluginContext#addFolderToScan(Path)} */
 	default void onModFolderAdded(Path folder) {}
 
-	/** Called once per archival file found in any of the folders added by {@link #addModFolders(Set)} or
-	 * {@link #onModFolderAdded(Path)}. This is only called for zips that aren't identified as quilt mods, and aren't
-	 * system files.
+	/** Called once per archival file found in any of the folders added by
+	 * {@link QuiltPluginContext#addFolderToScan(Path)}. This is only called for zips that aren't identified as quilt
+	 * mods, and aren't system files.
 	 * <p>
 	 * You can retrieve the file name of the original zip by using {@link QuiltPluginManager#getParent(Path)}.
 	 * <p>
 	 * Note that this will be called for <em>all</em> plugins, even if previous plugins loaded the zip as a mod!
 	 * 
-	 * @param root The root of the zip file.
-	 * @param fromClasspath TODO
+	 * @param zipFile The file of the zip.
+	 * @param root The root of a filesystem inside the zip file.
 	 * @param guiNode TODO
 	 * @return One or many {@link ModLoadOption}s if this plugin could load the given zip as a mod, or either null or an
 	 *         empty array if it couldn't.
 	 * @throws IOException if something went wrong while reading the zip and so an error message should be displayed. */
+	default ModLoadOption[] scanZip(Path zipFile, Path root, ModLocation location, QuiltTreeNode guiNode) throws IOException {
+		return scanZip(root, location, (PluginGuiTreeNode) guiNode);
+	}
+
+	/** @deprecated Override {@link #scanZip(Path, Path, ModLocation, QuiltTreeNode)} instead, as that doesn't use the
+	 *             deprecated {@link PluginGuiTreeNode} type. */
+	@Deprecated
 	default ModLoadOption[] scanZip(Path root, ModLocation location, PluginGuiTreeNode guiNode) throws IOException {
 		return null;
 	}
 
 	/** Called once per file encountered which loader can't open (I.E. those which are not passed to
-	 * {@link #scanZip(Path, boolean, PluginGuiTreeNode)}). However system files are not passed here.
+	 * {@link #scanZip(Path, Path, ModLocation, QuiltTreeNode)}). However system files are not passed here.
 	 * 
 	 * @param file
-	 * @param fromClasspath TODO
 	 * @param guiNode TODO
 	 * @return One or many {@link ModLoadOption}s if this plugin could load the given zip as a mod, or either null or an
 	 *         empty array if it couldn't.
 	 * @throws IOException if something went wrong while reading the zip and so an error message should be displayed. */
+	default ModLoadOption[] scanUnknownFile(Path file, ModLocation location, QuiltTreeNode guiNode)
+		throws IOException {
+		return scanUnknownFile(file, location, (PluginGuiTreeNode) guiNode);
+	}
+
+	/** @deprecated Override {@link #scanUnknownFile(Path, ModLocation, QuiltTreeNode)} instead, as that doesn't use the
+	 *             deprecated {@link PluginGuiTreeNode} type. */
+	@Deprecated
 	default ModLoadOption[] scanUnknownFile(Path file, ModLocation location, PluginGuiTreeNode guiNode)
 		throws IOException {
 		return null;
 	}
 
-	/** Called once per folder group added as a mod. This is called for both classpath groups, and folders added with
-	 * -Dloader.addMods=folder
+	/** Called once per folder group added as a mod. This is called for:
+	 * <ul>
+	 * <li>classpath groups</li>
+	 * <li>folders added with -Dloader.addMods=folder</li>
+	 * <li>Folders added via {@link QuiltPluginContext#addFileToScan(Path, QuiltTreeNode, boolean)}.</li>
+	 * </ul>
+	 * <p>
+	 * This is <em>not</em> called for the entire "mods/" folder, subfolders, or folders added by
+	 * {@link QuiltPluginContext#addFolderToScan(Path)}
 	 * 
-	 * @return One or many {@link ModLoadOption}s if this plugin could load the given zip as a mod, or either null or an
-	 *         empty array if it couldn't.
+	 * @return One or many {@link ModLoadOption}s if this plugin could load the given folder as a mod, or either null or
+	 *         an empty array if it couldn't.
 	 * @throws IOException if something went wrong while reading a file in the folder and so an error message should be
 	 *             displayed. */
+	default ModLoadOption[] scanFolder(Path folder, ModLocation location, QuiltTreeNode guiNode)
+		throws IOException {
+		return scanFolder(folder, location, (PluginGuiTreeNode) guiNode);
+	}
+
+	/** @deprecated Override {@link #scanFolder(Path, ModLocation, QuiltTreeNode)} instead, as that doesn't use the
+	 *             deprecated {@link PluginGuiTreeNode} type. */
+	@Deprecated
 	default ModLoadOption[] scanFolder(Path folder, ModLocation location, PluginGuiTreeNode guiNode)
 		throws IOException {
 		return null;
@@ -183,7 +211,7 @@ public interface QuiltLoaderPlugin {
 
 	/** Called whenever a new LoadOption is added, for plugins to add Rules based on this. (For example the default
 	 * plugin creates rules based on the dependencies and breaks sections of the quilt.mod.json if this option is a
-	 * {@link MainModLoadOption}).
+	 * {@link ModLoadOption}).
 	 * <p>
 	 * Most plugins are not expected to implement this. */
 	default void onLoadOptionAdded(LoadOption option) {}

--- a/src/main/java/org/quiltmc/loader/api/plugin/QuiltPluginContext.java
+++ b/src/main/java/org/quiltmc/loader/api/plugin/QuiltPluginContext.java
@@ -18,10 +18,8 @@ package org.quiltmc.loader.api.plugin;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.concurrent.Callable;
 
 import org.jetbrains.annotations.ApiStatus;
-import org.quiltmc.loader.api.ExtendedFileSystem;
 import org.quiltmc.loader.api.ExtendedFiles;
 import org.quiltmc.loader.api.gui.QuiltDisplayedError;
 import org.quiltmc.loader.api.gui.QuiltLoaderText;
@@ -60,6 +58,10 @@ public interface QuiltPluginContext {
 	/** @return The original {@link ModLoadOption} that this plugin is loaded from. */
 	ModLoadOption pluginOption();
 
+	/** @return A specialised Logger for the plugin to use. This will redirect to loaders internal Log, prefixed with
+	 *         the {@link #pluginId()} */
+	QuiltPluginLogger logger();
+
 	// ##############
 	// # Operations #
 	// ##############
@@ -81,7 +83,8 @@ public interface QuiltPluginContext {
 	 * or vice versa. Or any mod type of which a loader plugin can load).
 	 * 
 	 * @param guiNode The GUI node to display the loaded mod details under
-	 * @param direct True if the file is directly loaded rather than being included in another mod (see {@link ModLocation#isDirect()}) */
+	 * @param direct True if the file is directly loaded rather than being included in another mod (see
+	 *            {@link ModLocation#isDirect()}) */
 	void addFileToScan(Path file, QuiltTreeNode guiNode, boolean direct);
 
 	/** Adds an additional folder to scan for mods, which will be treated in the same way as the regular mods folder.
@@ -135,7 +138,8 @@ public interface QuiltPluginContext {
 	 * information.
 	 * <p>
 	 * This is preferable to calling {@link RuleContext#addOption(LoadOption)} since that adds a "floating" parent node
-	 * associated with the plugin itself, not where it might have been loaded from. 
+	 * associated with the plugin itself, not where it might have been loaded from.
+	 * 
 	 * @param fileNode The {@link PluginGuiTreeNode} which is shown in the 'Files' tab of the error window.
 	 * @deprecated {@link PluginGuiTreeNode} has moved to public API: {@link QuiltTreeNode}. As such please call
 	 *             {@link #addModLoadOption(ModLoadOption, QuiltTreeNode)} instead. */
@@ -146,17 +150,17 @@ public interface QuiltPluginContext {
 	 * information.
 	 * <p>
 	 * This is preferable to calling {@link RuleContext#addOption(LoadOption)} since that adds a "floating" parent node
-	 * associated with the plugin itself, not where it might have been loaded from. 
-	 * @param fileNode The {@link PluginGuiTreeNode} which is shown in the 'Files' tab of the error window.*/
+	 * associated with the plugin itself, not where it might have been loaded from.
+	 * 
+	 * @param fileNode The {@link PluginGuiTreeNode} which is shown in the 'Files' tab of the error window. */
 	void addModLoadOption(ModLoadOption mod, QuiltTreeNode fileNode);
 
-	/** Adds a tentative option which can be resolved later by
-	 * {@link QuiltLoaderPlugin#resolve(TentativeLoadOption)}, if it is selected.
-	 * 
+	/** Adds a tentative option which can be resolved later by {@link TentativeLoadOption#resolve()}, if it is selected.
+	 *
 	 * @param option */
 	<T extends LoadOption & TentativeLoadOption> void addTentativeOption(T option);
 
-	/** Only callable during {@link QuiltLoaderPlugin#handleError(java.util.Collection)} to identify the given rule as one
-	 * which can be removed for the purposes of error message generation. */
+	/** Only callable during {@link QuiltLoaderPlugin#handleError(java.util.Collection)} to identify the given rule as
+	 * one which can be removed for the purposes of error message generation. */
 	void blameRule(Rule rule);
 }

--- a/src/main/java/org/quiltmc/loader/api/plugin/QuiltPluginLogger.java
+++ b/src/main/java/org/quiltmc/loader/api/plugin/QuiltPluginLogger.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 FabricMC
+ * Copyright 2026 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.loader.api.plugin;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
+
+/** Logger for plugins. Mods generally won't need this, as they can use whatever logging library the game uses. */
+@ApiStatus.NonExtendable
+@QuiltLoaderInternal(QuiltLoaderInternalType.PLUGIN_API)
+public interface QuiltPluginLogger {
+	void error(String msg, Throwable exc);
+	void warn(String msg, Throwable exc);
+	void info(String msg, Throwable exc);
+	void debug(String msg, Throwable exc);
+	void trace(String msg, Throwable exc);
+
+	default void error(String msg) { error(msg, (Throwable) null); }
+	default void warn(String msg) { warn(msg, (Throwable) null); }
+	default void info(String msg) { info(msg, (Throwable) null); }
+	default void debug(String msg) { debug(msg, (Throwable) null); }
+	default void trace(String msg) { trace(msg, (Throwable) null); }
+
+	void errorFormat(String format, Object... args);
+	void warnFormat(String format, Object... args);
+	void infoFormat(String format, Object... args);
+	void debugFormat(String format, Object... args);
+	void traceFormat(String format, Object... args);
+}

--- a/src/main/java/org/quiltmc/loader/api/plugin/gui/package-info.java
+++ b/src/main/java/org/quiltmc/loader/api/plugin/gui/package-info.java
@@ -14,5 +14,6 @@
  * limitations under the License.
  */
 
-/** Deprecated package. Plugins should use {@link org.quiltmc.loader.api.gui.QuiltLoaderGui} instead. */
+/** Plugins should use {@link org.quiltmc.loader.api.gui.QuiltLoaderGui} instead. */
+@Deprecated
 package org.quiltmc.loader.api.plugin.gui;

--- a/src/main/java/org/quiltmc/loader/api/plugin/solver/ModLoadOption.java
+++ b/src/main/java/org/quiltmc/loader/api/plugin/solver/ModLoadOption.java
@@ -23,14 +23,17 @@ import java.nio.file.Path;
 import org.jetbrains.annotations.Nullable;
 import org.quiltmc.loader.api.FasterFiles;
 import org.quiltmc.loader.api.Version;
+import org.quiltmc.loader.api.gui.QuiltLoaderGui;
 import org.quiltmc.loader.api.gui.QuiltLoaderIcon;
 import org.quiltmc.loader.api.gui.QuiltLoaderText;
+import org.quiltmc.loader.api.gui.QuiltTreeNode;
 import org.quiltmc.loader.api.plugin.ModContainerExt;
+import org.quiltmc.loader.api.plugin.ModLocation;
 import org.quiltmc.loader.api.plugin.ModMetadataExt;
 import org.quiltmc.loader.api.plugin.ModMetadataExt.ModLoadType;
-import org.quiltmc.loader.api.plugin.gui.PluginGuiTreeNode;
 import org.quiltmc.loader.api.plugin.QuiltLoaderPlugin;
 import org.quiltmc.loader.api.plugin.QuiltPluginContext;
+import org.quiltmc.loader.api.plugin.gui.PluginGuiTreeNode;
 import org.quiltmc.loader.impl.filesystem.QuiltJoinedFileSystem;
 import org.quiltmc.loader.impl.filesystem.QuiltJoinedPath;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
@@ -65,8 +68,8 @@ public abstract class ModLoadOption extends LoadOption {
 	public abstract ModMetadataExt metadata();
 
 	/** @return The {@link Path} where this is loaded from. This should be either the Path that was passed to
-	 *         {@link QuiltLoaderPlugin#scanZip(Path, boolean, PluginGuiTreeNode)} or the Path that was passed to
-	 *         {@link QuiltLoaderPlugin#scanUnknownFile(Path, boolean, PluginGuiTreeNode)}. */
+	 *         {@link QuiltLoaderPlugin#scanZip(Path, Path, ModLocation, QuiltTreeNode)} or the Path that was passed to
+	 *         {@link QuiltLoaderPlugin#scanUnknownFile(Path, ModLocation, QuiltTreeNode)}. */
 	public abstract Path from();
 
 	/** @return The {@link Path} where this mod's classes and resources can be loaded from. */
@@ -83,17 +86,19 @@ public abstract class ModLoadOption extends LoadOption {
 
 	/** @return True if this mod MUST be loaded or false if this should be loaded depending on it's {@link ModLoadType}.
 	 *         Quilt returns true here for mods on the classpath and directly in the mods folder, but not when
-	 *         jar-in-jar'd. */
+	 *         jar-in-jar'd.
+	 *         <p>
+	 *         The standard quilt plugin will add a rule requiring that this load option is selected if this returns
+	 *         true. */
 	public abstract boolean isMandatory();
-
-	// TODO: How do we turn this into a ModContainer?
-	// like... how should we handle mods that need remapping vs those that don't?
-	// plus how is that meant to work with caches in the future?
 
 	/** @return The namespace to map classes from, or null if this mod shouldn't have it's classes remapped. */
 	@Nullable
 	public abstract String namespaceMappingFrom();
 
+	/** Checks to see if this mod should be stored in the transform cache, which will cache any and all transforms
+	 * applied. (Currently only remapping, "class hiding", class tweakers, and a few other quilt-loader transformers are
+	 * applied here - however in the future plugins may be able to transform any mod). */
 	public abstract boolean needsTransforming();
 
 	/** @param hasher The hasher to use when hashing files and folders.
@@ -128,12 +133,19 @@ public abstract class ModLoadOption extends LoadOption {
 		return modFileIcon().withDecoration(modTypeIcon());
 	}
 
-	/** Populates the given gui node with information about this mod. The {@link PluginGuiTreeNode#text()} will have
-	 * been set to the {@link #version()} before this method is called. */
+	/** @deprecated Please call/override the {@link QuiltTreeNode} version:
+	 *             {@link #populateModsTabInfo(QuiltTreeNode)} */
+	@Deprecated
 	public void populateModsTabInfo(PluginGuiTreeNode guiNode) {
 		guiNode.mainIcon(modTypeIcon());
 		guiNode.addChild(QuiltLoaderText.of(loader().manager().describePath(from())))//
-			.mainIcon(guiNode.manager().iconFolder());
+			.mainIcon(QuiltLoaderGui.iconFolder());
+	}
+
+	/** Populates the given gui node with information about this mod. The {@link PluginGuiTreeNode#text()} will have
+	 * been set to the {@link #version()} before this method is called. */
+	public void populateModsTabInfo(QuiltTreeNode guiNode) {
+		populateModsTabInfo((PluginGuiTreeNode) guiNode);
 	}
 
 	public abstract ModContainerExt convertToMod(Path transformedResourceRoot);

--- a/src/main/java/org/quiltmc/loader/api/plugin/solver/Rule.java
+++ b/src/main/java/org/quiltmc/loader/api/plugin/solver/Rule.java
@@ -21,10 +21,14 @@ import java.util.function.Consumer;
 
 import org.quiltmc.loader.api.ModDependency;
 import org.quiltmc.loader.api.gui.QuiltLoaderText;
+import org.quiltmc.loader.api.plugin.QuiltPluginContext;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
 
-/** Base definition of a link between one or more {@link LoadOption}s, that */
+/** Base definition of a link between one or more {@link LoadOption}s, that is used by the solver to determine whether
+ * to load those options.
+ * <p>
+ * Rules can be added and removed using {@link QuiltPluginContext#ruleContext()} */
 @QuiltLoaderInternal(QuiltLoaderInternalType.PLUGIN_API)
 public abstract class Rule {
 
@@ -47,15 +51,16 @@ public abstract class Rule {
 		return false;
 	}
 
+	/** Actually defines this rule. There's no limit to the number of definitions that this rule has. If this rule
+	 * changes, then you can request a redefinition using
+	 * {@link QuiltPluginContext#ruleContext()}.{@link RuleContext#redefine(Rule) redefine(Rule)} */
 	public abstract void define(RuleDefiner definer);
 
 	/** @return A description of the link. */
 	@Override
 	public abstract String toString();
 
-	/** Checks to see if this link is [...]
-	 * 
-	 * @deprecated Not used yet. In the future this will be used for better error message generation. */
+	/** @deprecated Not used yet. In the future this might be used for better error generation. */
 	@Deprecated
 	public boolean isNode() {
 		return true;

--- a/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/QuiltLoaderImpl.java
@@ -131,7 +131,7 @@ public final class QuiltLoaderImpl {
 
 	public static final int ASM_VERSION = Opcodes.ASM9;
 
-	public static final String VERSION = "0.30.2-beta.1";
+	public static final String VERSION = "0.31.0-beta.1";
 	public static final String MOD_ID = "quilt_loader";
 	public static final String DEFAULT_MODS_DIR = "mods";
 	public static final String DEFAULT_CACHE_DIR = ".cache";

--- a/src/main/java/org/quiltmc/loader/impl/filesystem/QuiltZipFileSystem.java
+++ b/src/main/java/org/quiltmc/loader/impl/filesystem/QuiltZipFileSystem.java
@@ -60,6 +60,7 @@ import org.quiltmc.loader.impl.filesystem.QuiltUnifiedEntry.QuiltUnifiedMountedF
 import org.quiltmc.loader.impl.util.DisconnectableByteChannel;
 import org.quiltmc.loader.impl.util.ExposedByteArrayOutputStream;
 import org.quiltmc.loader.impl.util.FileUtil;
+import org.quiltmc.loader.impl.util.HashUtil;
 import org.quiltmc.loader.impl.util.JavaVersionUtil;
 import org.quiltmc.loader.impl.util.LimitedInputStream;
 import org.quiltmc.loader.impl.util.QuiltLoaderCleanupTasks;
@@ -129,6 +130,11 @@ public class QuiltZipFileSystem extends QuiltMapFileSystem<QuiltZipFileSystem, Q
 				}
 			} else if (readLength == header.length && Arrays.equals(header, QuiltZipCustomCompressedWriter.PARTIAL_HEADER)) {
 				throw new PartiallyWrittenIOException();
+			} else if (readLength <= 3) {
+				throw new IOException("File is too small to contain a ZIP header! (" + readLength + " bytes)");
+			} else if (header[0] != 0x50 || header[1] != 0x4b || header[2] != 0x03 || header[3] != 0x04) {
+				String actuallyRead = HashUtil.hashToString(header, 0, readLength);
+				throw new IOException("File header doesn't match the ZIP magic number! " + actuallyRead);
 			} else {
 				pushback.reset();
 				initializeFromZip(pushback, zipPathPrefix);

--- a/src/main/java/org/quiltmc/loader/impl/launch/knot/Knot.java
+++ b/src/main/java/org/quiltmc/loader/impl/launch/knot/Knot.java
@@ -284,7 +284,7 @@ public final class Knot extends QuiltLauncherBase {
 
 	@Override
 	public void addToClassPath(Path path, ModContainer mod, URL origin, String... allowedPrefixes) {
-		Log.debug(LogCategory.KNOT, "Adding " + path.getFileSystem() + " " + path + " to classpath.");
+		Log.debug(LogCategory.KNOT, "Adding " + path.getFileSystem() + " " + path + " to classpath for mod " + mod);
 
 		try {
 			URL url = UrlUtil.asUrl(path);

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/InternalModMetadata.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/InternalModMetadata.java
@@ -17,13 +17,9 @@
 package org.quiltmc.loader.impl.metadata.qmj;
 
 import java.util.Collection;
-import java.util.Map;
 
-import org.quiltmc.loader.api.ModContainer;
 import org.quiltmc.loader.api.ModMetadata;
-import org.quiltmc.loader.api.ModMetadataToBeMovedToPlugins;
 import org.quiltmc.loader.api.plugin.ModMetadataExt;
-import org.quiltmc.loader.impl.metadata.FabricLoaderModMetadata;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
 

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/ModMetadataReader.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/ModMetadataReader.java
@@ -24,15 +24,16 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.jetbrains.annotations.Nullable;
-import org.quiltmc.parsers.json.JsonFormat;
-import org.quiltmc.parsers.json.JsonReader;
-import org.quiltmc.parsers.json.JsonToken;
-import org.quiltmc.parsers.json.ParseException;
 import org.quiltmc.loader.api.LoaderValue;
+import org.quiltmc.loader.api.gui.QuiltTreeNode;
 import org.quiltmc.loader.api.plugin.QuiltPluginManager;
 import org.quiltmc.loader.api.plugin.gui.PluginGuiTreeNode;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
+import org.quiltmc.parsers.json.JsonFormat;
+import org.quiltmc.parsers.json.JsonReader;
+import org.quiltmc.parsers.json.JsonToken;
+import org.quiltmc.parsers.json.ParseException;
 
 /**
  * The central class used to read a {@code quilt.mod.json}.
@@ -47,17 +48,27 @@ public final class ModMetadataReader {
 	private static final String SCHEMA_VERSION = "schema_version";
 
 	public static InternalModMetadata read(Path json) throws IOException, ParseException {
-		return read(json, null, null);
+		return read(json, null, (QuiltTreeNode)null);
 	}
 
+	@Deprecated
 	public static InternalModMetadata read(Path json, QuiltPluginManager manager, PluginGuiTreeNode warningNode) throws IOException, ParseException {
+		return read(Files.newInputStream(json), json, manager, warningNode);
+	}
+
+	public static InternalModMetadata read(Path json, QuiltPluginManager manager, QuiltTreeNode warningNode) throws IOException, ParseException {
 		return read(Files.newInputStream(json), json, manager, warningNode);
 	}
 
 	/** @deprecated Kept since this class is only LEGACY_EXPOSED. */
 	@Deprecated
 	public static InternalModMetadata read(InputStream json) throws IOException, ParseException {
-		return read(json, null, null, null);
+		return read(json, null, null, (QuiltTreeNode) null);
+	}
+
+	@Deprecated
+	public static InternalModMetadata read(InputStream json, Path path, QuiltPluginManager manager, PluginGuiTreeNode warningNode) throws IOException, ParseException {
+		return read(json, path, manager, (QuiltTreeNode) warningNode);
 	}
 
 	/**
@@ -69,7 +80,7 @@ public final class ModMetadataReader {
 	 * @throws ParseException if the json file has errors in the quilt.mod.json specification
 	 */
 	@SuppressWarnings("SwitchStatementWithTooFewBranches") // Switch statement intentionally used for future expandability
-	public static InternalModMetadata read(InputStream json, Path path, QuiltPluginManager manager, PluginGuiTreeNode warningNode) throws IOException, ParseException {
+	public static InternalModMetadata read(InputStream json, Path path, QuiltPluginManager manager, QuiltTreeNode warningNode) throws IOException, ParseException {
 		JsonLoaderValue value;
 
 		final JsonFormat format;

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/V1ModMetadataImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/V1ModMetadataImpl.java
@@ -16,6 +16,7 @@
 
 package org.quiltmc.loader.impl.metadata.qmj;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -29,6 +30,7 @@ import org.quiltmc.loader.api.ModContributor;
 import org.quiltmc.loader.api.ModDependency;
 import org.quiltmc.loader.api.ModLicense;
 import org.quiltmc.loader.api.Version;
+import org.quiltmc.loader.api.LoaderValue.LType;
 import org.quiltmc.loader.api.plugin.ModContainerExt;
 import org.quiltmc.loader.impl.metadata.FabricLoaderModMetadata;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
@@ -134,25 +136,41 @@ final class V1ModMetadataImpl implements InternalModMetadata {
 		this.accessWideners = Collections.unmodifiableCollection(builder.accessWideners);
 		this.environment = builder.env;
 
-		// Experimental
-		ModPlugin plugin;
+		// TODO: Declare a proper value "plugin" directly in the QMJ spec in the quilt_loader block
+		// then try that property first preferentially
+		// (I don't want to actually try to load the plugin property yet until we can get an RFC in)
 		@Nullable JsonLoaderValue e = root.get("experimental_quilt_loader_plugin");
 		if (e == null) {
-			plugin = null;
+			this.plugin = null;
 		} else {
-			if (!Boolean.getBoolean(SystemProperties.ENABLE_EXPERIMENTAL_LOADING_PLUGINS)) {
-				throw new ParseException("Mod " + asQuiltModMetadata().id() + " provides a loader plugin, which is not yet allowed!");
-			}
-			// humorous error message dirties the log + again makes it clear you shouldn't be doing this
-			Log.error(LogCategory.GENERAL, "MOD " + asQuiltModMetadata().id() + " PROVIDES A PLUGIN!" +
-					"MOD-PROVIDED PLUGINS ARE FOR AMUSEMENT PURPOSES ONLY." +
-					" NO WARRANTY IS PROVIDED, EXPRESS OR IMPLIED. CONTINUE AT YOUR OWN RISK.");
-
 			LoaderValue.LObject obj = e.asObject();
-			String clazz = obj.get("class").asString();
-			List<String> packages = obj.get("packages").asArray().stream().map(LoaderValue::asString).collect(Collectors.toList());
+			LoaderValue valClass = obj.get("class");
+			if (valClass == null || valClass.type() != LType.STRING) {
+				throw new ParseException(
+					"Expected to find a string called 'class' in the 'experimental_quilt_loader_plugin' block, but found "
+						+ valClass + "!"
+				);
+			}
+			String clazz = valClass.asString();
+			LoaderValue valPackages = obj.get("packages");
+			if (valPackages == null || valPackages.type() != LType.ARRAY) {
+				throw new ParseException(
+					"Expected to find an array called 'packages' in the 'experimental_quilt_loader_plugin' block, but found "
+						+ valPackages
+				);
+			}
+			List<String> packages = new ArrayList<>();
+			for (LoaderValue sub : valPackages.asArray()) {
+				if (sub == null || sub.type() != LType.STRING) {
+					throw new ParseException(
+						"Expected to find a string array called 'packages' in the 'experimental_quilt_loader_plugin' block, but found "
+							+ sub + " in " + valPackages
+					);
+				}
+				packages.add(sub.asString());
+			}
 
-			plugin = new ModPlugin() {
+			this.plugin = new ModPlugin() {
 				@Override
 				public String pluginClass() {
 					return clazz;
@@ -164,7 +182,6 @@ final class V1ModMetadataImpl implements InternalModMetadata {
 				}
 			};
 		}
-		this.plugin = plugin;
 	}
 
 	@Override

--- a/src/main/java/org/quiltmc/loader/impl/metadata/qmj/V1ModMetadataReader.java
+++ b/src/main/java/org/quiltmc/loader/impl/metadata/qmj/V1ModMetadataReader.java
@@ -32,11 +32,8 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import net.fabricmc.api.EnvType;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.quiltmc.parsers.json.ParseException;
 import org.quiltmc.loader.api.LoaderValue;
 import org.quiltmc.loader.api.LoaderValue.LType;
 import org.quiltmc.loader.api.ModDependency;
@@ -48,29 +45,37 @@ import org.quiltmc.loader.api.VersionFormatException;
 import org.quiltmc.loader.api.VersionRange;
 import org.quiltmc.loader.api.gui.QuiltLoaderGui;
 import org.quiltmc.loader.api.gui.QuiltLoaderText;
+import org.quiltmc.loader.api.gui.QuiltTreeNode;
+import org.quiltmc.loader.api.gui.QuiltWarningLevel;
 import org.quiltmc.loader.api.plugin.ModMetadataExt.ModEntrypoint;
 import org.quiltmc.loader.api.plugin.ModMetadataExt.ModLoadType;
 import org.quiltmc.loader.api.plugin.QuiltPluginManager;
 import org.quiltmc.loader.api.plugin.gui.PluginGuiTreeNode;
-import org.quiltmc.loader.api.plugin.gui.PluginGuiTreeNode.WarningLevel;
 import org.quiltmc.loader.impl.metadata.qmj.JsonLoaderValue.ObjectImpl;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
-
-import net.fabricmc.loader.api.metadata.ModEnvironment;
-
 import org.quiltmc.loader.impl.util.SystemProperties;
 import org.quiltmc.loader.impl.util.log.Log;
 import org.quiltmc.loader.impl.util.log.LogCategory;
+import org.quiltmc.parsers.json.ParseException;
+
+import net.fabricmc.loader.api.metadata.ModEnvironment;
+
+import net.fabricmc.api.EnvType;
 
 // TODO: Figure out a way to not need to always specify JsonLoaderValue everywhere so we can let other users and plugins have location data.
 @QuiltLoaderInternal(QuiltLoaderInternalType.LEGACY_EXPOSED)
 public final class V1ModMetadataReader {
 	public static V1ModMetadataImpl read(JsonLoaderValue.ObjectImpl root) {
-		return read(root, null, null, null);
+		return read(root, null, null, (QuiltTreeNode) null);
 	}
 
+	@Deprecated
 	public static V1ModMetadataImpl read(JsonLoaderValue.ObjectImpl root, Path path, QuiltPluginManager manager, PluginGuiTreeNode parentNode) {
+		return read(root, path, manager, (QuiltTreeNode) parentNode);
+	}
+
+	public static V1ModMetadataImpl read(JsonLoaderValue.ObjectImpl root, Path path, QuiltPluginManager manager, QuiltTreeNode parentNode) {
 		// Read loader category
 		@Nullable JsonLoaderValue quiltLoader = root.get("quilt_loader");
 
@@ -110,12 +115,12 @@ public final class V1ModMetadataReader {
 
 	final Path from;
 	final QuiltPluginManager manager;
-	final PluginGuiTreeNode warningNode;
-	PluginGuiTreeNode modJsonNode = null;
+	final QuiltTreeNode warningNode;
+	QuiltTreeNode modJsonNode = null;
 	boolean loggedAnyWarnings = false;
 	boolean loggedDeprecatedArrayDepends = false;
 
-	private V1ModMetadataReader(Path from, QuiltPluginManager manager, PluginGuiTreeNode warningNode) {
+	private V1ModMetadataReader(Path from, QuiltPluginManager manager, QuiltTreeNode warningNode) {
 		this.from = from;
 		this.manager = manager;
 		this.warningNode = warningNode;
@@ -760,7 +765,7 @@ public final class V1ModMetadataReader {
 					if (warningNode != null) {
 						createModJsonNode()
 							.addChild(QuiltLoaderText.of("Uses deprecated array format for declaring dependencies."))
-							.setDirectLevel(WarningLevel.CONCERN)
+							.level(QuiltWarningLevel.CONCERN)
 							.addChild(QuiltLoaderText.of("See " + RFC_56_LINK + " for more information on how to fix this"));
 					}
 				}
@@ -820,7 +825,7 @@ public final class V1ModMetadataReader {
 					if (warningNode != null) {
 						createModJsonNode()
 							.addChild(QuiltLoaderText.of(msg))
-							.setDirectLevel(WarningLevel.CONCERN)
+							.level(QuiltWarningLevel.CONCERN)
 							.addChild(QuiltLoaderText.of("See " + RFC_56_LINK + " for more information on how to fix this"));
 					}
 				}
@@ -837,13 +842,13 @@ public final class V1ModMetadataReader {
 		Log.warn(LogCategory.DISCOVERY, "Warnings for quilt.mod.json at: '" + describedPath + "'");
 	}
 
-	private PluginGuiTreeNode createModJsonNode() {
+	private QuiltTreeNode createModJsonNode() {
 		if (warningNode == null) {
 			throw new IllegalStateException("Check 'warningNode' first!");
 		}
 		if (modJsonNode == null) {
 			modJsonNode = warningNode.addChild(QuiltLoaderText.of("quilt.mod.json"));
-			modJsonNode.mainIcon(QuiltLoaderGui.iconJsonFile()).subIcon(QuiltLoaderGui.iconQuilt());
+			modJsonNode.icon(QuiltLoaderGui.iconJsonFile().withDecoration(QuiltLoaderGui.iconQuilt()));
 		}
 		return modJsonNode;
 	}

--- a/src/main/java/org/quiltmc/loader/impl/plugin/BasePluginContext.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/BasePluginContext.java
@@ -19,11 +19,11 @@ package org.quiltmc.loader.impl.plugin;
 import java.nio.file.Path;
 import java.util.Collection;
 
-import org.quiltmc.loader.api.plugin.QuiltPluginContext;
 import org.quiltmc.loader.api.gui.QuiltDisplayedError;
 import org.quiltmc.loader.api.gui.QuiltLoaderText;
 import org.quiltmc.loader.api.gui.QuiltTreeNode;
 import org.quiltmc.loader.api.gui.QuiltTreeNode.SortOrder;
+import org.quiltmc.loader.api.plugin.QuiltPluginContext;
 import org.quiltmc.loader.api.plugin.QuiltPluginManager;
 import org.quiltmc.loader.api.plugin.gui.PluginGuiTreeNode;
 import org.quiltmc.loader.api.plugin.solver.LoadOption;
@@ -86,8 +86,8 @@ abstract class BasePluginContext implements QuiltPluginContext {
 
 	@Override
 	public void lockZip(Path path) {
-		// TODO Auto-generated method stub
-		throw new AbstractMethodError("// TODO: Implement this!");
+		// NO-OP
+		// currently opened zips get GC'd, and we can't explicitly close them
 	}
 
 	@Override
@@ -106,6 +106,7 @@ abstract class BasePluginContext implements QuiltPluginContext {
 	}
 
 	@Override
+	@Deprecated
 	public void addModLoadOption(ModLoadOption mod, PluginGuiTreeNode guiNode) {
 		manager.addSingleModOption(mod, BasePluginContext.this, true, (QuiltStatusNode) guiNode);
 	}

--- a/src/main/java/org/quiltmc/loader/impl/plugin/BuiltinPluginContext.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/BuiltinPluginContext.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.quiltmc.loader.api.plugin.QuiltLoaderPlugin;
+import org.quiltmc.loader.api.plugin.QuiltPluginLogger;
 import org.quiltmc.loader.api.plugin.solver.ModLoadOption;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
@@ -32,6 +33,11 @@ class BuiltinPluginContext extends BasePluginContext {
 	public BuiltinPluginContext(QuiltPluginManagerImpl manager, String pluginId, QuiltLoaderPlugin plugin) {
 		super(manager, pluginId);
 		this.plugin = plugin;
+	}
+
+	@Override
+	public QuiltPluginLogger logger() {
+		throw new UnsupportedOperationException("Builtin plugins don't need their own loggers.");
 	}
 
 	@Override

--- a/src/main/java/org/quiltmc/loader/impl/plugin/PluginLoggerImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/PluginLoggerImpl.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.loader.impl.plugin;
+
+import org.quiltmc.loader.api.plugin.QuiltPluginLogger;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
+import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
+import org.quiltmc.loader.impl.util.log.Log;
+import org.quiltmc.loader.impl.util.log.LogCategory;
+
+@QuiltLoaderInternal(QuiltLoaderInternalType.NEW_INTERNAL)
+class PluginLoggerImpl implements QuiltPluginLogger {
+	final LogCategory category;
+
+	PluginLoggerImpl(String name) {
+		this.category = LogCategory.create("Plugin", name);
+	}
+
+	@Override
+	public void error(String msg, Throwable exc) {
+		Log.error(category, msg, exc);
+	}
+
+	@Override
+	public void warn(String msg, Throwable exc) {
+		Log.warn(category, msg, exc);
+	}
+
+	@Override
+	public void info(String msg, Throwable exc) {
+		Log.info(category, msg, exc);
+	}
+
+	@Override
+	public void debug(String msg, Throwable exc) {
+		Log.debug(category, msg, exc);
+	}
+
+	@Override
+	public void trace(String msg, Throwable exc) {
+		Log.trace(category, msg, exc);
+	}
+
+	@Override
+	public void errorFormat(String format, Object... args) {
+		Log.error(category, format, args);
+	}
+
+	@Override
+	public void warnFormat(String format, Object... args) {
+		Log.warn(category, format, args);
+	}
+
+	@Override
+	public void infoFormat(String format, Object... args) {
+		Log.info(category, format, args);
+	}
+
+	@Override
+	public void debugFormat(String format, Object... args) {
+		Log.debug(category, format, args);
+	}
+
+	@Override
+	public void traceFormat(String format, Object... args) {
+		Log.trace(category, format, args);
+	}
+}

--- a/src/main/java/org/quiltmc/loader/impl/plugin/QuiltPluginContextImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/QuiltPluginContextImpl.java
@@ -25,6 +25,7 @@ import org.quiltmc.loader.api.LoaderValue;
 import org.quiltmc.loader.api.plugin.LoaderValueFactory;
 import org.quiltmc.loader.api.plugin.ModMetadataExt.ModPlugin;
 import org.quiltmc.loader.api.plugin.QuiltLoaderPlugin;
+import org.quiltmc.loader.api.plugin.QuiltPluginLogger;
 import org.quiltmc.loader.api.plugin.solver.ModLoadOption;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
@@ -34,6 +35,7 @@ public class QuiltPluginContextImpl extends BasePluginContext {
 
 	final ModLoadOption optionFrom;
 	final Path pluginPath;
+	final PluginLoggerImpl logger;
 	final QuiltPluginClassLoader classLoader;
 	final QuiltLoaderPlugin plugin;
 
@@ -44,6 +46,8 @@ public class QuiltPluginContextImpl extends BasePluginContext {
 		super(manager, from.id());
 		this.optionFrom = from;
 		this.pluginPath = from.resourceRoot();
+		this.logger = new PluginLoggerImpl(pluginId);
+		logger.debug("Starting plugin from " + manager.describePath(pluginPath));
 
 		ClassLoader parent = Thread.currentThread().getContextClassLoader();
 		ModPlugin pluginMeta = from.metadata().plugin();
@@ -67,6 +71,11 @@ public class QuiltPluginContextImpl extends BasePluginContext {
 	@Override
 	public Path pluginPath() {
 		return pluginPath;
+	}
+
+	@Override
+	public QuiltPluginLogger logger() {
+		return logger;
 	}
 
 	@Override

--- a/src/main/java/org/quiltmc/loader/impl/plugin/QuiltPluginManagerImpl.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/QuiltPluginManagerImpl.java
@@ -45,7 +45,6 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -886,7 +885,7 @@ public class QuiltPluginManagerImpl implements QuiltPluginManager {
 
 			for (ModLoadOption option : set.all) {
 				QuiltStatusNode modNode = gui.addChild(QuiltLoaderText.of(option.version().toString()), SortOrder.ALPHABETICAL_ORDER);
-				option.populateModsTabInfo(modNode);
+				option.populateModsTabInfo((QuiltTreeNode)modNode);
 				if (result != null && result.directMods().containsValue(option)) {
 					modNode.icon(modNode.icon().withDecoration(QuiltLoaderGui.iconTick()));
 				}
@@ -1790,7 +1789,8 @@ public class QuiltPluginManagerImpl implements QuiltPluginManager {
 				if (loadState instanceof PathLoadState.Folder) {
 					scanFolderWithPlugin(loadState, pluginCtx, guiNode);
 				} else if (loadState instanceof PathLoadState.Zip) {
-					scanZipWithPlugin(((PathLoadState.Zip) loadState).insideZipRoot, loadState, pluginCtx, guiNode);
+					PathLoadState.Zip zip = (PathLoadState.Zip) loadState;
+					scanZipWithPlugin(zip.path, zip.insideZipRoot, loadState, pluginCtx, guiNode);
 				} else if (loadState instanceof PathLoadState.UnknownFile) {
 					scanUnknownFileWithPlugin(loadState, pluginCtx, guiNode);
 				}
@@ -2014,7 +2014,7 @@ public class QuiltPluginManagerImpl implements QuiltPluginManager {
 	private List<ModLoadOption> scanFolderWithPlugin(PathLoadState loadState, BasePluginContext ctx, QuiltStatusNode guiNode) {
 		ModLoadOption[] mods;
 		try {
-			mods = ctx.plugin().scanFolder(loadState.path, loadState.location, guiNode);
+			mods = ctx.plugin().scanFolder(loadState.path, loadState.location, (QuiltTreeNode)guiNode);
 		} catch (IOException e) {
 			// FOR NOW
 			// TODO: Proper error handling!
@@ -2192,7 +2192,7 @@ public class QuiltPluginManagerImpl implements QuiltPluginManager {
 			boolean isQuilt = false;
 
 			for (BasePluginContext ctx : plugins.values()) {
-				List<ModLoadOption> list = scanZipWithPlugin(zipRoot, loadState, ctx, guiNode);
+				List<ModLoadOption> list = scanZipWithPlugin(zipFile, zipRoot, loadState, ctx, guiNode);
 				if (!list.isEmpty() && ctx == theQuiltPlugin.context()) {
 					isQuilt = true;
 					break;
@@ -2213,10 +2213,10 @@ public class QuiltPluginManagerImpl implements QuiltPluginManager {
 		}
 	}
 
-	private List<ModLoadOption> scanZipWithPlugin(Path zipRoot, PathLoadState loadState, BasePluginContext ctx, QuiltStatusNode guiNode) {
+	private List<ModLoadOption> scanZipWithPlugin(Path zipFile, Path zipRoot, PathLoadState loadState, BasePluginContext ctx, QuiltStatusNode guiNode) {
 		ModLoadOption[] mods;
 		try {
-			mods = ctx.plugin().scanZip(zipRoot, loadState.location, guiNode);
+			mods = ctx.plugin().scanZip(zipFile, zipRoot, loadState.location, guiNode);
 		} catch (IOException e) {
 			// FOR NOW
 			// TODO: Proper error handling!
@@ -2277,7 +2277,7 @@ public class QuiltPluginManagerImpl implements QuiltPluginManager {
 		Path file = loadState.path;
 		ModLoadOption[] mods;
 		try {
-			mods = ctx.plugin().scanUnknownFile(file, loadState.location, guiNode);
+			mods = ctx.plugin().scanUnknownFile(file, loadState.location, (QuiltTreeNode)guiNode);
 		} catch (IOException e) {
 			// FOR NOW
 			// TODO: Proper error handling!

--- a/src/main/java/org/quiltmc/loader/impl/plugin/quilt/StandardQuiltPlugin.java
+++ b/src/main/java/org/quiltmc/loader/impl/plugin/quilt/StandardQuiltPlugin.java
@@ -45,6 +45,8 @@ import org.quiltmc.loader.api.gui.QuiltLoaderGui;
 import org.quiltmc.loader.api.gui.QuiltLoaderIcon;
 import org.quiltmc.loader.api.gui.QuiltLoaderText;
 import org.quiltmc.loader.api.gui.QuiltTreeNode;
+import org.quiltmc.loader.api.gui.QuiltTreeNode.SortOrder;
+import org.quiltmc.loader.api.gui.QuiltWarningLevel;
 import org.quiltmc.loader.api.QuiltLoader;
 import org.quiltmc.loader.api.Version;
 import org.quiltmc.loader.api.VersionRange;
@@ -52,8 +54,6 @@ import org.quiltmc.loader.api.plugin.ModLocation;
 import org.quiltmc.loader.api.plugin.ModMetadataExt;
 import org.quiltmc.loader.api.plugin.QuiltPluginContext;
 import org.quiltmc.loader.api.plugin.QuiltPluginManager;
-import org.quiltmc.loader.api.plugin.gui.PluginGuiTreeNode;
-import org.quiltmc.loader.api.plugin.gui.PluginGuiTreeNode.SortOrder;
 import org.quiltmc.loader.api.plugin.solver.AliasedLoadOption;
 import org.quiltmc.loader.api.plugin.solver.LoadOption;
 import org.quiltmc.loader.api.plugin.solver.ModLoadOption;
@@ -261,9 +261,9 @@ public class StandardQuiltPlugin extends BuiltinQuiltPlugin {
 	}
 
 	@Override
-	public ModLoadOption[] scanZip(Path root, ModLocation location, PluginGuiTreeNode guiNode) throws IOException {
+	public ModLoadOption[] scanZip(Path zipFile, Path root, ModLocation location, QuiltTreeNode guiNode) throws IOException {
 
-		Path parent = context().manager().getParent(root);
+		Path parent = zipFile;
 
 		if (!parent.getFileName().toString().endsWith(".jar")) {
 			return null;
@@ -273,12 +273,12 @@ public class StandardQuiltPlugin extends BuiltinQuiltPlugin {
 	}
 
 	@Override
-	public ModLoadOption[] scanFolder(Path folder, ModLocation location, PluginGuiTreeNode guiNode) throws IOException {
+	public ModLoadOption[] scanFolder(Path folder, ModLocation location, QuiltTreeNode guiNode) throws IOException {
 		return scan0(folder, QuiltLoaderGui.iconFolder(), location, false, guiNode);
 	}
 
 	private ModLoadOption[] scan0(Path root, QuiltLoaderIcon fileIcon, ModLocation location, boolean isZip,
-		PluginGuiTreeNode guiNode) throws IOException {
+		QuiltTreeNode guiNode) throws IOException {
 
 		Path qmj = root.resolve("quilt.mod.json");
 		Path qmj5 = root.resolve("quilt.mod.json5");
@@ -380,13 +380,13 @@ public class StandardQuiltPlugin extends BuiltinQuiltPlugin {
 					continue;
 				}
 
-				PluginGuiTreeNode jarNode = guiNode.addChild(QuiltLoaderText.of(jar), SortOrder.ALPHABETICAL_ORDER);
+				QuiltTreeNode jarNode = guiNode.addChild(QuiltLoaderText.of(jar), SortOrder.ALPHABETICAL_ORDER);
 				if (DISBALE_BUILTIN_MIXIN_EXTRAS) {
 					if (QuiltLoaderImpl.MOD_ID.equals(meta.id())) {
 						if (inner.toString().startsWith("/META-INF/jars/mixinextras-")) {
 							Log.info(LogCategory.GENERAL, "Disabling loader's builtin mixin extras library due to command line flag");
 							jarNode.addChild(QuiltLoaderText.translate("mixin_extras.disabled"));
-							jarNode.mainIcon(QuiltLoaderGui.iconDisabled());
+							jarNode.icon(QuiltLoaderGui.iconDisabled());
 							continue;
 						}
 					}
@@ -414,7 +414,7 @@ public class StandardQuiltPlugin extends BuiltinQuiltPlugin {
 			);
 
 			guiNode.addChild(QuiltLoaderText.translate("gui.text.invalid_metadata", parse.getMessage()))//
-				.setError(parse, error);
+				.level(QuiltWarningLevel.ERROR);
 			return null;
 		}
 	}

--- a/src/main/java/org/quiltmc/loader/impl/transformer/QuiltTransformer.java
+++ b/src/main/java/org/quiltmc/loader/impl/transformer/QuiltTransformer.java
@@ -19,22 +19,19 @@ package org.quiltmc.loader.impl.transformer;
 import java.util.Collection;
 import java.util.HashSet;
 
-import net.fabricmc.api.EnvType;
-
-import net.fabricmc.classtweaker.api.ClassTweaker;
-
-import net.fabricmc.classtweaker.classvisitor.AccessWidenerClassVisitor;
-
 import org.jetbrains.annotations.Nullable;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
 import org.quiltmc.loader.api.plugin.solver.ModLoadOption;
 import org.quiltmc.loader.impl.QuiltLoaderImpl;
 import org.quiltmc.loader.impl.game.GameProvider;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternal;
 import org.quiltmc.loader.impl.util.QuiltLoaderInternalType;
 import org.quiltmc.loader.impl.util.SystemProperties;
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.ClassWriter;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.classtweaker.api.ClassTweaker;
 
 @QuiltLoaderInternal(QuiltLoaderInternalType.NEW_INTERNAL)
 final class QuiltTransformer {

--- a/src/main/java/org/quiltmc/loader/impl/util/HashUtil.java
+++ b/src/main/java/org/quiltmc/loader/impl/util/HashUtil.java
@@ -55,8 +55,13 @@ public class HashUtil {
 	}
 
 	public static String hashToString(byte[] hash) {
+		return hashToString(hash, 0, hash.length);
+	}
+
+	public static String hashToString(byte[] hash, int offset, int length) {
 		StringBuilder sb = new StringBuilder();
-		for (byte b : hash) {
+		for (int index = offset; index < offset + length; index++) {
+			byte b = hash[index];
 			int i = Byte.toUnsignedInt(b);
 			if (i < 0xF) {
 				sb.append("0");

--- a/src/main/resources/changelog/0.31.0.txt
+++ b/src/main/resources/changelog/0.31.0.txt
@@ -1,0 +1,10 @@
+Changes:
+
+- [#503] Make loader plugins no longer require the "loader.experimental.allow_loading_plugins" flag to be set to true to load.
+- [#505] Cleaned up a few parts of the loader plugin API
+    - Added `QuiltPluginLogger` for pluggins to perform logging
+    - Deprecated all references to the deprecated `org.quiltmc.loader.api.plugin.gui` package,
+       as the `loader.api.gui` package should be used instead.
+    - Changed zip file handling to only treat files as ZIPs if they start with the 4-byte zip header.
+        - All other files will now correctly be send to "scanUnknownFile"
+    - Cleaned up a little bit of documentaion


### PR DESCRIPTION
I still need to RFC loader plugins, but they are basically not going to change after this, so there's little reason to prevent people from using them right now.

This superseeds #503, and should release properly long before we remove the deprecated `plugins.gui` package in #499